### PR TITLE
device id validator and boot-time validator enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add validator to validate consistent device id and enhancements to boot-time validator. [#18](https://github.com/xmidt-org/interpreter/pull/18)
 
 ## [v0.0.3]
 - Add labels for errors for prometheus error metrics logging. [#15](https://github.com/xmidt-org/interpreter/pull/15)

--- a/event.go
+++ b/event.go
@@ -40,8 +40,11 @@ var (
 	ErrBootTimeNotFound = errors.New("boot-time not found")
 	ErrTypeNotFound     = errors.New("type not found")
 
-	// EventRegex is the regex that an event's destination must match in order to parser the device id properly.
+	// EventRegex is the regex that an event's destination must match in order to parse the device id properly.
 	EventRegex = regexp.MustCompile(`^(?P<event>[^/]+)/((?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+))/(?P<type>[^/\s]+)`)
+
+	// DeviceIDRegex is used to parse a device id from anywhere
+	DeviceIDRegex = regexp.MustCompile(`(?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+)`)
 )
 
 // Event is the struct that contains the wrp.Message fields along with the birthdate

--- a/event.go
+++ b/event.go
@@ -43,7 +43,7 @@ var (
 	// EventRegex is the regex that an event's destination must match in order to parse the device id properly.
 	EventRegex = regexp.MustCompile(`^(?P<event>[^/]+)/((?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+))/(?P<type>[^/\s]+)`)
 
-	// DeviceIDRegex is used to parse a device id from anywhere
+	// DeviceIDRegex is used to parse a device id from anywhere.
 	DeviceIDRegex = regexp.MustCompile(`(?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+)`)
 )
 

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -123,7 +123,7 @@ type InconsistentIDErr struct {
 }
 
 func (e InconsistentIDErr) Error() string {
-	return fmt.Sprintf("inconsistent device id. IDs seen: %v", e.IDs)
+	return "inconsistent device id"
 }
 
 func (e InconsistentIDErr) Tag() Tag {
@@ -142,7 +142,7 @@ func (e BootDurationErr) Error() string {
 		return fmt.Sprintf("boot duration error: %v", e.OriginalErr)
 	}
 
-	return fmt.Sprintf("boot duration error")
+	return "boot duration error"
 }
 
 func (e BootDurationErr) Tag() Tag {

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -39,8 +39,13 @@ type MetricsLogError interface {
 	ErrorLabel() string
 }
 
+type TaggedError interface {
+	Tag() Tag
+}
+
 type InvalidEventErr struct {
 	OriginalErr error
+	ErrorTag    Tag
 }
 
 func (e InvalidEventErr) Error() string {
@@ -63,8 +68,13 @@ func (e InvalidEventErr) ErrorLabel() string {
 	return invalidEventReason
 }
 
+func (e InvalidEventErr) Tag() Tag {
+	return e.ErrorTag
+}
+
 type InvalidBootTimeErr struct {
 	OriginalErr error
+	ErrorTag    Tag
 }
 
 func (e InvalidBootTimeErr) Error() string {
@@ -80,6 +90,13 @@ func (e InvalidBootTimeErr) Unwrap() error {
 
 func (e InvalidBootTimeErr) ErrorLabel() string {
 	return invalidBootTimeReason
+}
+
+func (e InvalidBootTimeErr) Tag() Tag {
+	if e.ErrorTag == Unknown {
+		return InvalidBootTime
+	}
+	return e.ErrorTag
 }
 
 type InvalidBirthdateErr struct {

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -118,6 +118,37 @@ func (e InvalidBirthdateErr) ErrorLabel() string {
 	return invalidBirthdateReason
 }
 
+type InconsistentIDErr struct {
+	IDs []string
+}
+
+func (e InconsistentIDErr) Error() string {
+	return fmt.Sprintf("inconsistent device id. IDs seen: %v", e.IDs)
+}
+
+func (e InconsistentIDErr) Tag() Tag {
+	return InconsistentDeviceID
+}
+
+type BootDurationErr struct {
+	OriginalErr error
+	ErrorTag    Tag
+	Destination string
+	Timestamps  []int64
+}
+
+func (e BootDurationErr) Error() string {
+	if e.OriginalErr != nil {
+		return fmt.Sprintf("boot duration error: %v", e.OriginalErr)
+	}
+
+	return fmt.Sprintf("boot duration error")
+}
+
+func (e BootDurationErr) Tag() Tag {
+	return e.ErrorTag
+}
+
 type InvalidDestinationErr struct {
 	OriginalErr error
 	ErrLabel    string

--- a/validation/errors_test.go
+++ b/validation/errors_test.go
@@ -16,6 +16,7 @@ func TestInvalidEventErr(t *testing.T) {
 		description   string
 		underlyingErr error
 		expectedLabel string
+		tag           Tag
 	}{
 		{
 			description:   "No underlying error",
@@ -31,18 +32,24 @@ func TestInvalidEventErr(t *testing.T) {
 			underlyingErr: testErr,
 			expectedLabel: "test_error",
 		},
+		{
+			description:   "With tag",
+			tag:           InvalidBootTime,
+			expectedLabel: invalidEventReason,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			err := InvalidEventErr{OriginalErr: tc.underlyingErr}
+			err := InvalidEventErr{OriginalErr: tc.underlyingErr, ErrorTag: tc.tag}
 			if tc.underlyingErr != nil {
 				assert.Contains(err.Error(), tc.underlyingErr.Error())
 			}
 			assert.Contains(err.Error(), "event invalid")
 			assert.Equal(tc.underlyingErr, err.Unwrap())
 			assert.Equal(tc.expectedLabel, err.ErrorLabel())
+			assert.Equal(tc.tag, err.Tag())
 		})
 	}
 }
@@ -52,6 +59,7 @@ func TestInvalidBootTimeErr(t *testing.T) {
 		description   string
 		underlyingErr error
 		expectedLabel string
+		tag           Tag
 	}{
 		{
 			description:   "No underlying error",
@@ -62,17 +70,30 @@ func TestInvalidBootTimeErr(t *testing.T) {
 			underlyingErr: errors.New("test error"),
 			expectedLabel: invalidBootTimeReason,
 		},
+		{
+			description:   "Underlying tag",
+			expectedLabel: invalidBootTimeReason,
+			tag:           OldBootTime,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			err := InvalidBootTimeErr{OriginalErr: tc.underlyingErr}
+			if tc.tag != Unknown {
+				err.ErrorTag = tc.tag
+			}
 			if tc.underlyingErr != nil {
 				assert.Contains(err.Error(), tc.underlyingErr.Error())
 			}
 			assert.Equal(tc.underlyingErr, err.Unwrap())
 			assert.Equal(tc.expectedLabel, err.ErrorLabel())
+			if tc.tag != Unknown {
+				assert.Equal(tc.tag, err.Tag())
+			} else {
+				assert.Equal(InvalidBootTime, err.Tag())
+			}
 		})
 	}
 }

--- a/validation/errors_test.go
+++ b/validation/errors_test.go
@@ -165,3 +165,45 @@ func TestInvalidDestinationErr(t *testing.T) {
 		})
 	}
 }
+
+func TestInconsistentIDErr(t *testing.T) {
+	err := InconsistentIDErr{}
+	assert.Equal(t, InconsistentDeviceID, err.Tag())
+	assert.Contains(t, err.Error(), "inconsistent device id")
+}
+
+func TestBootDurationErr(t *testing.T) {
+	tests := []struct {
+		description   string
+		underlyingErr error
+		underlyingTag Tag
+		expectedTag   Tag
+	}{
+		{
+			description: "No underlying error",
+			expectedTag: Unknown,
+		},
+		{
+			description:   "Underlying error",
+			underlyingErr: errors.New("test error"),
+			expectedTag:   Unknown,
+		},
+		{
+			description:   "Underlying tag",
+			underlyingTag: FastBoot,
+			expectedTag:   FastBoot,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := BootDurationErr{OriginalErr: tc.underlyingErr, ErrorTag: tc.underlyingTag}
+			if tc.underlyingErr != nil {
+				assert.Contains(err.Error(), tc.underlyingErr.Error())
+			}
+			assert.Contains(err.Error(), "boot duration error")
+			assert.Equal(tc.expectedTag, err.Tag())
+		})
+	}
+}

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -30,7 +30,7 @@ var (
 		MissingBootTime:      "missing_boot_time",
 		OldBootTime:          "old_boot_time",
 		InvalidBootTime:      "invalid_boot_time",
-		FastBoot:             "fast_boot",
+		FastBoot:             "suspiciously_fast_boot",
 		Unknown:              "unknown",
 	}
 
@@ -40,7 +40,7 @@ var (
 		"missing_boot_time":      MissingBootTime,
 		"old_boot_time":          OldBootTime,
 		"invalid_boot_time":      InvalidBootTime,
-		"fast_boot":              FastBoot,
+		"suspiciously_fast_boot": FastBoot,
 		"unknown":                Unknown,
 	}
 )

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -1,0 +1,56 @@
+package validation
+
+import "strings"
+
+// Tag is an enum used to flag the problems with an event.
+type Tag int
+
+func (t Tag) String() string {
+	if val, ok := tagToString[t]; ok {
+		return val
+	}
+
+	return "unknown"
+}
+
+const (
+	Unknown Tag = iota
+	Pass
+	InconsistentDeviceID
+	MissingBootTime
+	OldBootTime
+	InvalidBootTime
+	FastBoot
+)
+
+var (
+	tagToString = map[Tag]string{
+		Pass:                 "pass",
+		InconsistentDeviceID: "inconsistent_device_id",
+		MissingBootTime:      "missing_boot_time",
+		OldBootTime:          "old_boot_time",
+		InvalidBootTime:      "invalid_boot_time",
+		FastBoot:             "fast_boot",
+		Unknown:              "unknown",
+	}
+
+	stringToTag = map[string]Tag{
+		"pass":                   Pass,
+		"inconsistent_device_id": InconsistentDeviceID,
+		"missing_boot_time":      MissingBootTime,
+		"old_boot_time":          OldBootTime,
+		"invalid_boot_time":      InvalidBootTime,
+		"fast_boot":              FastBoot,
+		"unknown":                Unknown,
+	}
+)
+
+// ParseTag is used to convert a string to a Tag. Returns Unknown if the string is not known.
+func ParseTag(str string) Tag {
+	str = strings.Replace(strings.ToLower(str), " ", "_", -1)
+	if val, ok := stringToTag[str]; ok {
+		return val
+	}
+
+	return Unknown
+}

--- a/validation/tag_test.go
+++ b/validation/tag_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestString(t *testing.T) {
+	tests := []Tag{Pass, Unknown, InvalidBootTime, OldBootTime, InconsistentDeviceID, MissingBootTime, FastBoot}
+	for _, tag := range tests {
+		assert.Equal(t, tagToString[tag], tag.String())
+	}
+
+	var nonExistentTag Tag
+	nonExistentTag = 1000
+	assert.Equal(t, "unknown", nonExistentTag.String())
+}
 func TestParseTag(t *testing.T) {
 	tests := []struct {
 		testStr     string
@@ -20,7 +30,7 @@ func TestParseTag(t *testing.T) {
 			expectedTag: Unknown,
 		},
 		{
-			testStr:     "Fast_Boot",
+			testStr:     "Suspiciously_Fast_Boot",
 			expectedTag: FastBoot,
 		},
 		{

--- a/validation/tag_test.go
+++ b/validation/tag_test.go
@@ -1,0 +1,39 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTag(t *testing.T) {
+	tests := []struct {
+		testStr     string
+		expectedTag Tag
+	}{
+		{
+			testStr:     "pass",
+			expectedTag: Pass,
+		},
+		{
+			testStr:     "random",
+			expectedTag: Unknown,
+		},
+		{
+			testStr:     "Fast_Boot",
+			expectedTag: FastBoot,
+		},
+		{
+			testStr:     "Inconsistent device id",
+			expectedTag: InconsistentDeviceID,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testStr, func(t *testing.T) {
+			assert := assert.New(t)
+			tag := ParseTag(tc.testStr)
+			assert.Equal(tc.expectedTag, tag)
+		})
+	}
+}

--- a/validation/tag_test.go
+++ b/validation/tag_test.go
@@ -12,8 +12,7 @@ func TestString(t *testing.T) {
 		assert.Equal(t, tagToString[tag], tag.String())
 	}
 
-	var nonExistentTag Tag
-	nonExistentTag = 1000
+	var nonExistentTag Tag = 1000
 	assert.Equal(t, "unknown", nonExistentTag.String())
 }
 func TestParseTag(t *testing.T) {

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -286,7 +286,7 @@ func TestDeviceIDValidator(t *testing.T) {
 					"key": "some-value/mac:112233445566",
 				},
 			},
-			expectedIDs:        []string{"mac:112233445566", "serial:12345678", "mac:112233445566", "mac:112233445566"},
+			expectedIDs:        []string{"mac:112233445566", "serial:12345678"},
 			expectedConsistent: false,
 		},
 		{
@@ -298,7 +298,7 @@ func TestDeviceIDValidator(t *testing.T) {
 					"key": "some-value/mac:112233445566",
 				},
 			},
-			expectedIDs:        []string{"mac:112233445566", "mac:123", "mac:112233445566"},
+			expectedIDs:        []string{"mac:112233445566", "mac:123"},
 			expectedConsistent: false,
 		},
 		{
@@ -310,7 +310,7 @@ func TestDeviceIDValidator(t *testing.T) {
 					"key": "some-value/mac:112233445566/serial:112233445566",
 				},
 			},
-			expectedIDs:        []string{"mac:112233445566", "mac:112233445566", "mac:112233445566", "serial:112233445566"},
+			expectedIDs:        []string{"mac:112233445566", "serial:112233445566"},
 			expectedConsistent: false,
 		},
 		{
@@ -355,7 +355,7 @@ func TestDeviceIDValidator(t *testing.T) {
 				var e InconsistentIDErr
 				assert.True(errors.As(err, &e))
 				assert.Equal(InconsistentDeviceID, e.Tag())
-				assert.Equal(tc.expectedIDs, e.IDs)
+				assert.ElementsMatch(tc.expectedIDs, e.IDs)
 			} else {
 				assert.Nil(err)
 			}
@@ -598,11 +598,13 @@ func TestDeviceIDComparison(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.checkID, func(t *testing.T) {
 			assert := assert.New(t)
-			var ids []string
+			ids := make(map[string]bool)
 			consistent, id, ids := deviceIDComparison(tc.checkID, tc.foundID, ids)
 			assert.Equal(tc.consistent, consistent)
 			assert.Equal(tc.expectedFoundID, id)
-			assert.Equal(tc.expectedIDs, ids)
+			for _, id := range tc.expectedIDs {
+				assert.True(ids[id])
+			}
 		})
 	}
 }

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -258,7 +258,7 @@ func TestDestinationValidator(t *testing.T) {
 }
 
 func TestDeviceIDValidator(t *testing.T) {
-	val := DeviceIDValidator()
+	val := ConsistentDeviceIDValidator()
 	tests := []struct {
 		description        string
 		event              interpreter.Event
@@ -274,6 +274,17 @@ func TestDeviceIDValidator(t *testing.T) {
 				},
 			},
 			expectedConsistent: true,
+		},
+		{
+			description: "inconsistent source",
+			event: interpreter.Event{
+				Source:      "mac:112233445566/serial:12345678",
+				Destination: "event:device-status/mac:112233445566/something-something",
+				Metadata: map[string]string{
+					"key": "some-value/mac:112233445566",
+				},
+			},
+			expectedConsistent: false,
 		},
 		{
 			description: "inconsistent destination",
@@ -452,6 +463,110 @@ func TestDeviceIDComparison(t *testing.T) {
 			consistent, id := deviceIDComparison(tc.checkID, tc.foundID)
 			assert.Equal(tc.consistent, consistent)
 			assert.Equal(tc.expectedFoundID, id)
+		})
+	}
+}
+
+func TestDestinationTimestampValidator(t *testing.T) {
+	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
+	assert.Nil(t, err)
+	tests := []struct {
+		description string
+		event       interpreter.Event
+		duration    time.Duration
+		valid       bool
+	}{
+		{
+			description: "valid with timestamp",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/%d", now.Add(2*time.Minute).Unix()),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    true,
+		},
+		{
+			description: "valid with multiple timestamps",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/%d/something-something/%d/%d", now.Add(2*time.Minute).Unix(), now.Add(3*time.Minute).Unix(), now.Add(time.Minute).Unix()),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    true,
+		},
+		{
+			description: "valid with no timestamps",
+			event: interpreter.Event{
+				Destination: "event:device-status/serial:112233445566/",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    true,
+		},
+		{
+			description: "invalid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/%d", now.Add(5*time.Second).Unix()),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    false,
+		},
+		{
+			description: "past timestamp",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/%d", now.Add(-5*time.Second).Unix()),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    true,
+		},
+		{
+			description: "regular int",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/123"),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    true,
+		},
+		{
+			description: "duration",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/2s"),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: 10 * time.Second,
+			valid:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			val := DestinationTimestampValidator(tc.duration)
+			valid, err := val(tc.event)
+			assert.Equal(tc.valid, valid)
+			if !tc.valid {
+				var taggedError TaggedError
+				assert.True(errors.Is(err, ErrFastBoot))
+				assert.True(errors.As(err, &taggedError))
+				assert.Equal(FastBoot, taggedError.Tag())
+			}
 		})
 	}
 }

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -264,6 +264,7 @@ func TestDeviceIDValidator(t *testing.T) {
 		description        string
 		event              interpreter.Event
 		expectedConsistent bool
+		expectedIDs        []string
 	}{
 		{
 			description: "pass",
@@ -285,6 +286,7 @@ func TestDeviceIDValidator(t *testing.T) {
 					"key": "some-value/mac:112233445566",
 				},
 			},
+			expectedIDs:        []string{"mac:112233445566", "serial:12345678", "mac:112233445566", "mac:112233445566"},
 			expectedConsistent: false,
 		},
 		{
@@ -296,6 +298,7 @@ func TestDeviceIDValidator(t *testing.T) {
 					"key": "some-value/mac:112233445566",
 				},
 			},
+			expectedIDs:        []string{"mac:112233445566", "mac:123", "mac:112233445566"},
 			expectedConsistent: false,
 		},
 		{
@@ -307,6 +310,7 @@ func TestDeviceIDValidator(t *testing.T) {
 					"key": "some-value/mac:112233445566/serial:112233445566",
 				},
 			},
+			expectedIDs:        []string{"mac:112233445566", "mac:112233445566", "mac:112233445566", "serial:112233445566"},
 			expectedConsistent: false,
 		},
 		{
@@ -348,9 +352,10 @@ func TestDeviceIDValidator(t *testing.T) {
 			pass, err := val(tc.event)
 			assert.Equal(tc.expectedConsistent, pass)
 			if !tc.expectedConsistent {
-				var e TaggedError
+				var e InconsistentIDErr
 				assert.True(errors.As(err, &e))
 				assert.Equal(InconsistentDeviceID, e.Tag())
+				assert.Equal(tc.expectedIDs, e.IDs)
 			} else {
 				assert.Nil(err)
 			}


### PR DESCRIPTION
Adds validators to validate timestamps in event destination and ensure that device id is consistent throughout the event. Enhances boot-time validator to determine if a boot-time is invalid or just old.

Closes #17 