### PR TITLE
Validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add validator to validate consistent device id and enhancements to boot-time validator. [#18](https://github.com/xmidt-org/interpreter/pull/18)
+- Add validator to validate consistent device id and enhancements to boot-time validator. Introduce tags and `TaggedError` interface. [#18](https://github.com/xmidt-org/interpreter/pull/18)
+- Replace `MetricsLogError` with `TaggedError`. Add validator to futher validate birthdates and event-types. [#21](https://github.com/xmidt-org/interpreter/pull/21)
 
 ## [v0.0.3]
 - Add labels for errors for prometheus error metrics logging. [#15](https://github.com/xmidt-org/interpreter/pull/15)

--- a/event.go
+++ b/event.go
@@ -45,6 +45,18 @@ var (
 
 	// DeviceIDRegex is used to parse a device id from anywhere.
 	DeviceIDRegex = regexp.MustCompile(`(?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+)`)
+
+	// EventTypes lists all of the possible device status events.
+	EventTypes = map[string]bool{
+		"reboot-pending":              true,
+		"offline":                     true,
+		"online":                      true,
+		"operational":                 true,
+		"fully-manageable":            true,
+		"non-operational":             true,
+		"firmware-download-started":   true,
+		"firmware-download-completed": true,
+	}
 )
 
 // Event is the struct that contains the wrp.Message fields along with the birthdate

--- a/event.go
+++ b/event.go
@@ -31,6 +31,12 @@ import (
 
 const (
 	BootTimeKey = "/boot-time"
+
+	TypeSubexpName      = "type"
+	IDSubexpName        = "ID"
+	AuthoritySubexpName = "authority"
+	EventSubexpName     = "event"
+	SchemeSubexpName    = "scheme"
 )
 
 var (
@@ -38,13 +44,14 @@ var (
 	ErrBirthdateParse   = errors.New("unable to parse birthdate from payload")
 	ErrBootTimeParse    = errors.New("unable to parse boot-time")
 	ErrBootTimeNotFound = errors.New("boot-time not found")
+	ErrEventRegex       = errors.New("event regex is wrong")
 	ErrTypeNotFound     = errors.New("type not found")
 
 	// EventRegex is the regex that an event's destination must match in order to parse the device id properly.
-	EventRegex = regexp.MustCompile(`^(?P<event>[^/]+)/((?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+))/(?P<type>[^/\s]+)`)
+	EventRegex = regexp.MustCompile(fmt.Sprintf(`^(?P<%s>[^/]+)/(?P<%s>(?P<%s>(?i)mac|uuid|dns|serial):(?P<%s>[^/]+))/(?P<%s>[^/\s]+)`, EventSubexpName, IDSubexpName, SchemeSubexpName, AuthoritySubexpName, TypeSubexpName))
 
 	// DeviceIDRegex is used to parse a device id from anywhere.
-	DeviceIDRegex = regexp.MustCompile(`(?P<prefix>(?i)mac|uuid|dns|serial):(?P<id>[^/]+)`)
+	DeviceIDRegex = regexp.MustCompile(fmt.Sprintf(`(?P<%s>(?i)mac|uuid|dns|serial):(?P<%s>[^/]+)`, SchemeSubexpName, AuthoritySubexpName))
 
 	// EventTypes lists all of the possible device status events.
 	EventTypes = map[string]bool{
@@ -125,24 +132,26 @@ func (e Event) BootTime() (int64, error) {
 	return bootTime, err
 }
 
-// DeviceID gets the device id based on the event regex.
+// DeviceID gets the device id from the event's destination based on the event regex.
 func (e Event) DeviceID() (string, error) {
+	index := EventRegex.SubexpIndex(IDSubexpName)
 	match := EventRegex.FindStringSubmatch(e.Destination)
-	if len(match) < 3 {
+	if len(match) < index+1 {
 		return "", ErrParseDeviceID
 	}
 
-	return match[2], nil
+	return match[index], nil
 }
 
 // EventType returns the event type from the event's destination.
 func (e Event) EventType() (string, error) {
+	index := EventRegex.SubexpIndex(TypeSubexpName)
 	match := EventRegex.FindStringSubmatch(e.Destination)
-	if len(match) < 6 {
+	if len(match) < index+1 {
 		return "", ErrTypeNotFound
 	}
 
-	return match[5], nil
+	return match[index], nil
 }
 
 func getBirthDate(payload []byte) (time.Time, bool) {

--- a/history/errors_test.go
+++ b/history/errors_test.go
@@ -1,44 +1,44 @@
 package history
 
 import (
-	"errors"
 	"testing"
+
+	"github.com/xmidt-org/interpreter/validation"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/interpreter"
 )
 
 func TestEventCompareErr(t *testing.T) {
-	testErr := errors.New("test error")
+	const testTag validation.Tag = 1000
+	testErr := testTaggedError{tag: testTag}
 	tests := []struct {
 		description   string
 		err           ComparatorErr
 		expectedErr   error
 		expectedEvent interpreter.Event
-		expectedLabel string
+		expectedTag   validation.Tag
 	}{
 		{
-			description:   "No underlying error or event",
-			err:           ComparatorErr{},
-			expectedLabel: comparatorErrLabel,
+			description: "No underlying error or event",
+			err:         ComparatorErr{},
 		},
 		{
-			description:   "Underlying error",
-			err:           ComparatorErr{OriginalErr: testErr},
-			expectedErr:   testErr,
-			expectedLabel: comparatorErrLabel,
+			description: "Underlying error",
+			err:         ComparatorErr{OriginalErr: testErr},
+			expectedErr: testErr,
+			expectedTag: testTag,
 		},
 		{
 			description:   "Underlying event",
 			err:           ComparatorErr{ComparisonEvent: interpreter.Event{Destination: "test-dest"}},
 			expectedEvent: interpreter.Event{Destination: "test-dest"},
-			expectedLabel: comparatorErrLabel,
 		},
 		{
-			description:   "With Label",
-			err:           ComparatorErr{OriginalErr: testErr, ErrLabel: "test_error"},
-			expectedErr:   testErr,
-			expectedLabel: "test_error",
+			description: "With Tag",
+			err:         ComparatorErr{OriginalErr: testErr, ErrorTag: 2000},
+			expectedErr: testErr,
+			expectedTag: 2000,
 		},
 	}
 
@@ -51,35 +51,35 @@ func TestEventCompareErr(t *testing.T) {
 			assert.Contains(tc.err.Error(), "comparator error")
 			assert.Equal(tc.expectedErr, tc.err.Unwrap())
 			assert.Equal(tc.expectedEvent, tc.err.Event())
-			assert.Equal(tc.expectedLabel, tc.err.ErrorLabel())
+			assert.Equal(tc.expectedTag, tc.err.Tag())
 		})
 	}
 }
 
 func TestEventFinderErr(t *testing.T) {
-	testErr := errors.New("test error")
+	const testTag validation.Tag = 1000
+	testErr := testTaggedError{tag: testTag}
 	tests := []struct {
-		description   string
-		err           EventFinderErr
-		expectedErr   error
-		expectedLabel string
+		description string
+		err         EventFinderErr
+		expectedErr error
+		expectedTag validation.Tag
 	}{
 		{
-			description:   "No underlying error or event",
-			err:           EventFinderErr{},
-			expectedLabel: finderErrLabel,
+			description: "No underlying error or event",
+			err:         EventFinderErr{},
 		},
 		{
-			description:   "Underlying error",
-			err:           EventFinderErr{OriginalErr: testErr},
-			expectedErr:   testErr,
-			expectedLabel: finderErrLabel,
+			description: "Underlying error",
+			err:         EventFinderErr{OriginalErr: testErr},
+			expectedErr: testErr,
+			expectedTag: testTag,
 		},
 		{
-			description:   "With Label",
-			err:           EventFinderErr{OriginalErr: testErr, ErrLabel: "test_error"},
-			expectedErr:   testErr,
-			expectedLabel: "test_error",
+			description: "With Tag",
+			err:         EventFinderErr{OriginalErr: testErr, ErrorTag: 2000},
+			expectedErr: testErr,
+			expectedTag: 2000,
 		},
 	}
 
@@ -91,7 +91,7 @@ func TestEventFinderErr(t *testing.T) {
 			}
 			assert.Contains(tc.err.Error(), "failed to find event")
 			assert.Equal(tc.expectedErr, tc.err.Unwrap())
-			assert.Equal(tc.expectedLabel, tc.err.ErrorLabel())
+			assert.Equal(tc.expectedTag, tc.err.Tag())
 		})
 	}
 }

--- a/history/eventComparator.go
+++ b/history/eventComparator.go
@@ -77,7 +77,7 @@ func OlderBootTimeComparator() ComparatorFunc {
 
 		// if this event has a boot-time more recent than the latest one, return an error
 		if bootTime > latestBootTime {
-			return true, ComparatorErr{OriginalErr: errNewerBootTime, ErrorTag: validation.OutdatedBootTime, ComparisonEvent: baseEvent}
+			return true, ComparatorErr{OriginalErr: errNewerBootTime, ErrorTag: validation.NewerBootTimeFound, ComparisonEvent: baseEvent}
 		}
 
 		return false, nil
@@ -105,7 +105,7 @@ func DuplicateEventComparator() ComparatorFunc {
 		newEventType, _ := newEvent.EventType()
 
 		// see if event types match
-		if strings.ToLower(strings.TrimSpace(baseEventType)) == strings.ToLower(strings.TrimSpace(newEventType)) {
+		if strings.EqualFold(strings.TrimSpace(baseEventType), strings.TrimSpace(newEventType)) {
 			latestBootTime, _ := newEvent.BootTime()
 			bootTime, err := baseEvent.BootTime()
 			if err != nil || bootTime <= 0 {

--- a/history/eventComparator.go
+++ b/history/eventComparator.go
@@ -22,16 +22,12 @@ import (
 	"regexp"
 
 	"github.com/xmidt-org/interpreter"
+	"github.com/xmidt-org/interpreter/validation"
 )
 
 var (
 	errNewerBootTime  = errors.New("newer boot-time found")
 	errDuplicateEvent = errors.New("duplicate event found")
-)
-
-const (
-	newerBootTimeReason  = "newer_boottime_found"
-	duplicateEventReason = "duplicate_event_found"
 )
 
 // Comparator compares two events and returns true if the condition has been matched.
@@ -81,7 +77,7 @@ func OlderBootTimeComparator() ComparatorFunc {
 
 		// if this event has a boot-time more recent than the latest one, return an error
 		if bootTime > latestBootTime {
-			return true, ComparatorErr{OriginalErr: errNewerBootTime, ErrLabel: newerBootTimeReason, ComparisonEvent: baseEvent}
+			return true, ComparatorErr{OriginalErr: errNewerBootTime, ErrorTag: validation.OutdatedBootTime, ComparisonEvent: baseEvent}
 		}
 
 		return false, nil
@@ -101,7 +97,7 @@ func DuplicateEventComparator(eventType *regexp.Regexp) ComparatorFunc {
 			return false, nil
 		}
 
-		// see if event is the type we are looking for
+		// see if event is the type we are looking forß
 		if eventType.MatchString(baseEvent.Destination) && eventType.MatchString(newEvent.Destination) {
 			latestBootTime, _ := newEvent.BootTime()
 			bootTime, err := baseEvent.BootTime()
@@ -112,7 +108,7 @@ func DuplicateEventComparator(eventType *regexp.Regexp) ComparatorFunc {
 			// If the boot-time is the same as the latestBootTime, and the birthdate is older or equal,
 			// this means that newEvent is a duplicate.
 			if bootTime == latestBootTime && baseEvent.Birthdate <= newEvent.Birthdate {
-				return true, ComparatorErr{OriginalErr: errDuplicateEvent, ErrLabel: duplicateEventReason, ComparisonEvent: baseEvent}
+				return true, ComparatorErr{OriginalErr: errDuplicateEvent, ErrorTag: validation.DuplicateEvent, ComparisonEvent: baseEvent}
 			}
 		}
 

--- a/history/eventComparator.go
+++ b/history/eventComparator.go
@@ -19,7 +19,7 @@ package history
 
 import (
 	"errors"
-	"regexp"
+	"strings"
 
 	"github.com/xmidt-org/interpreter"
 	"github.com/xmidt-org/interpreter/validation"
@@ -88,17 +88,24 @@ func OlderBootTimeComparator() ComparatorFunc {
 // DuplicateEventComparator returns a ComparatorFunc to check and see if newEvent is a duplicate. A duplicate event
 // in this case is defined as sharing the same event type and boot-time as the base event while having a birthdate
 // that is equal to or newer than baseEvent's birthdate. If newEvent is found to be a duplicate, it returns true and
-// an error. DuplicateEventComparator checks that newEvent and baseEvent match the eventType.
-// It assumes that newEvent has a valid boot-time and does not do any error-checking of newEvent's boot-time.
-func DuplicateEventComparator(eventType *regexp.Regexp) ComparatorFunc {
+// an error. It assumes that newEvent has a valid boot-time and event-type and does not do any error-checking
+// of newEvent's boot-time or event type.
+func DuplicateEventComparator() ComparatorFunc {
 	return func(baseEvent interpreter.Event, newEvent interpreter.Event) (bool, error) {
 		// baseEvent is newEvent, no need to compare boot-times
 		if baseEvent.TransactionUUID == newEvent.TransactionUUID {
 			return false, nil
 		}
 
-		// see if event is the type we are looking for
-		if eventType.MatchString(baseEvent.Destination) && eventType.MatchString(newEvent.Destination) {
+		baseEventType, err := baseEvent.EventType()
+		if err != nil {
+			return false, nil
+		}
+
+		newEventType, _ := newEvent.EventType()
+
+		// see if event types match
+		if strings.ToLower(strings.TrimSpace(baseEventType)) == strings.ToLower(strings.TrimSpace(newEventType)) {
 			latestBootTime, _ := newEvent.BootTime()
 			bootTime, err := baseEvent.BootTime()
 			if err != nil || bootTime <= 0 {

--- a/history/eventComparator.go
+++ b/history/eventComparator.go
@@ -97,7 +97,7 @@ func DuplicateEventComparator(eventType *regexp.Regexp) ComparatorFunc {
 			return false, nil
 		}
 
-		// see if event is the type we are looking forß
+		// see if event is the type we are looking for
 		if eventType.MatchString(baseEvent.Destination) && eventType.MatchString(newEvent.Destination) {
 			latestBootTime, _ := newEvent.BootTime()
 			bootTime, err := baseEvent.BootTime()

--- a/history/eventComparator_test.go
+++ b/history/eventComparator_test.go
@@ -91,7 +91,7 @@ func TestOlderBootTimeComparator(t *testing.T) {
 			incomingEvent: latestEvent,
 			match:         true,
 			expectedErr:   errNewerBootTime,
-			expectedTag:   validation.OutdatedBootTime,
+			expectedTag:   validation.NewerBootTimeFound,
 		},
 		{
 			description: "latest boot-time invalid",
@@ -104,7 +104,7 @@ func TestOlderBootTimeComparator(t *testing.T) {
 			},
 			match:       true,
 			expectedErr: errNewerBootTime,
-			expectedTag: validation.OutdatedBootTime,
+			expectedTag: validation.NewerBootTimeFound,
 		},
 	}
 

--- a/history/eventComparator_test.go
+++ b/history/eventComparator_test.go
@@ -119,9 +119,10 @@ func TestOlderBootTimeComparator(t *testing.T) {
 						err, tc.expectedErr),
 				)
 
-				var logError validation.MetricsLogError
-				assert.True(errors.As(err, &logError))
-				assert.Equal(newerBootTimeReason, logError.ErrorLabel())
+				var tagError validation.TaggedError
+				assert.True(errors.As(err, &tagError))
+				//TODO: revise
+				// assert.Equal(newerBootTimeReason, logError.ErrorLabel())
 			}
 		})
 	}
@@ -278,9 +279,10 @@ func TestDuplicateEventComparator(t *testing.T) {
 					fmt.Errorf("error [%v] doesn't contain error [%v] in its err chain",
 						err, tc.expectedErr),
 				)
-				var logError validation.MetricsLogError
-				assert.True(errors.As(err, &logError))
-				assert.Equal(duplicateEventReason, logError.ErrorLabel())
+				var tagError validation.TaggedError
+				assert.True(errors.As(err, &tagError))
+				// TODO: revise
+				// assert.Equal(duplicateEventReason, logError.ErrorLabel())
 			}
 		})
 	}

--- a/history/eventComparator_test.go
+++ b/history/eventComparator_test.go
@@ -51,6 +51,7 @@ func TestOlderBootTimeComparator(t *testing.T) {
 		incomingEvent interpreter.Event
 		match         bool
 		expectedErr   error
+		expectedTag   validation.Tag
 	}{
 		{
 			description: "valid event",
@@ -91,6 +92,7 @@ func TestOlderBootTimeComparator(t *testing.T) {
 			incomingEvent: latestEvent,
 			match:         true,
 			expectedErr:   errNewerBootTime,
+			expectedTag:   validation.OutdatedBootTime,
 		},
 		{
 			description: "latest boot-time invalid",
@@ -103,6 +105,7 @@ func TestOlderBootTimeComparator(t *testing.T) {
 			},
 			match:       true,
 			expectedErr: errNewerBootTime,
+			expectedTag: validation.OutdatedBootTime,
 		},
 	}
 
@@ -121,8 +124,7 @@ func TestOlderBootTimeComparator(t *testing.T) {
 
 				var tagError validation.TaggedError
 				assert.True(errors.As(err, &tagError))
-				//TODO: revise
-				// assert.Equal(newerBootTimeReason, logError.ErrorLabel())
+				assert.Equal(tc.expectedTag, tagError.Tag())
 			}
 		})
 	}
@@ -146,6 +148,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		incomingEvent interpreter.Event
 		match         bool
 		expectedErr   error
+		expectedTag   validation.Tag
 	}{
 		{
 			description: "valid event",
@@ -228,6 +231,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 			incomingEvent: latestEvent,
 			match:         true,
 			expectedErr:   errDuplicateEvent,
+			expectedTag:   validation.DuplicateEvent,
 		},
 		{
 			description: "duplicate found, same birthdate",
@@ -240,6 +244,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 			incomingEvent: latestEvent,
 			match:         true,
 			expectedErr:   errDuplicateEvent,
+			expectedTag:   validation.DuplicateEvent,
 		},
 		{
 			description: "duplicate found, later birthdate",
@@ -281,8 +286,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 				)
 				var tagError validation.TaggedError
 				assert.True(errors.As(err, &tagError))
-				// TODO: revise
-				// assert.Equal(duplicateEventReason, logError.ErrorLabel())
+				assert.Equal(tc.expectedTag, tagError.Tag())
 			}
 		})
 	}

--- a/history/eventComparator_test.go
+++ b/history/eventComparator_test.go
@@ -3,7 +3,6 @@ package history
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -133,15 +132,14 @@ func TestOlderBootTimeComparator(t *testing.T) {
 func TestDuplicateEventComparator(t *testing.T) {
 	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
 	assert.Nil(t, err)
-	destRegex := regexp.MustCompile(".*/online")
 	latestEvent := interpreter.Event{
-		Destination:     "mac:112233445566/online",
+		Destination:     "event:device-status/mac:112233445566/online",
 		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 		TransactionUUID: "test",
 		Birthdate:       now.UnixNano(),
 	}
 
-	comparator := DuplicateEventComparator(destRegex)
+	comparator := DuplicateEventComparator()
 	tests := []struct {
 		description   string
 		historyEvent  interpreter.Event
@@ -153,7 +151,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "valid event",
 			historyEvent: interpreter.Event{
-				Destination: "mac:112233445566/online",
+				Destination: "event:device-status/mac:112233445566/online",
 				Metadata: map[string]string{
 					interpreter.BootTimeKey: fmt.Sprint(now.Add(-30 * time.Minute).Unix()),
 				},
@@ -166,7 +164,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "same event uuid",
 			historyEvent: interpreter.Event{
-				Destination: "mac:112233445566/online",
+				Destination: "event:device-status/mac:112233445566/online",
 				Metadata: map[string]string{
 					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
 				},
@@ -192,7 +190,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "new event type mismatch",
 			historyEvent: interpreter.Event{
-				Destination: "mac:112233445566/online",
+				Destination: "event:device-status/mac:112233445566/online",
 				Metadata: map[string]string{
 					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
 				},
@@ -212,7 +210,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "boot-time missing",
 			historyEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{},
 				TransactionUUID: "abc",
 				Birthdate:       now.UnixNano(),
@@ -223,7 +221,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "duplicate found, older birthdate",
 			historyEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 				TransactionUUID: "abc",
 				Birthdate:       now.Add(-1 * time.Minute).UnixNano(),
@@ -236,7 +234,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "duplicate found, same birthdate",
 			historyEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 				TransactionUUID: "abc",
 				Birthdate:       now.UnixNano(),
@@ -249,7 +247,7 @@ func TestDuplicateEventComparator(t *testing.T) {
 		{
 			description: "duplicate found, later birthdate",
 			historyEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 				TransactionUUID: "abc",
 				Birthdate:       now.Add(time.Minute).UnixNano(),

--- a/history/eventFinder_test.go
+++ b/history/eventFinder_test.go
@@ -3,7 +3,6 @@ package history
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -40,7 +39,7 @@ func TestEventHistoryIterator(t *testing.T) {
 	assert.Nil(t, err)
 	fatalError := errors.New("invalid event")
 	latestEvent := interpreter.Event{
-		Destination:     "mac:112233445566/online",
+		Destination:     "event:device-status/mac:112233445566/online",
 		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 		Birthdate:       now.UnixNano(),
 		TransactionUUID: "latest",
@@ -62,7 +61,7 @@ func TestEventHistoryIterator(t *testing.T) {
 				},
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 					},
@@ -94,7 +93,7 @@ func TestEventHistoryIterator(t *testing.T) {
 			events: []testEvent{
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 					},
@@ -102,7 +101,7 @@ func TestEventHistoryIterator(t *testing.T) {
 				},
 			},
 			latestEvent: interpreter.Event{
-				Destination: "mac:112233445566/online",
+				Destination: "event:device-status/mac:112233445566/online",
 				Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 			},
 			expectedEvent: interpreter.Event{},
@@ -113,7 +112,7 @@ func TestEventHistoryIterator(t *testing.T) {
 			events: []testEvent{
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 					},
@@ -121,7 +120,7 @@ func TestEventHistoryIterator(t *testing.T) {
 				},
 			},
 			latestEvent: interpreter.Event{
-				Destination: "mac:112233445566/online",
+				Destination: "event:device-status/mac:112233445566/online",
 				Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 				Metadata:    map[string]string{interpreter.BootTimeKey: "-1"},
 			},
@@ -133,7 +132,7 @@ func TestEventHistoryIterator(t *testing.T) {
 			events: []testEvent{
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 					},
@@ -141,7 +140,7 @@ func TestEventHistoryIterator(t *testing.T) {
 				},
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-3 * time.Minute).Unix())},
 						Birthdate:   now.Add(-3 * time.Minute).UnixNano(),
 					},
@@ -202,13 +201,13 @@ func testError(t *testing.T, past bool) {
 			description: "Non-existent boot-time",
 			events: []interpreter.Event{
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 				},
 			},
 			latestEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Birthdate:       now.UnixNano(),
 				TransactionUUID: "latest",
 			},
@@ -219,13 +218,13 @@ func testError(t *testing.T, past bool) {
 			description: "Invalid boot-time",
 			events: []interpreter.Event{
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 				},
 			},
 			latestEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: "-1"},
 				Birthdate:       now.UnixNano(),
 				TransactionUUID: "latest",
@@ -237,13 +236,13 @@ func testError(t *testing.T, past bool) {
 			description: "Fatal error",
 			events: []interpreter.Event{
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(1 * time.Hour).Unix())},
 					Birthdate:   now.Add(1 * time.Hour).UnixNano(),
 				},
 			},
 			latestEvent: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 				Birthdate:       now.UnixNano(),
 				TransactionUUID: "latest",
@@ -267,15 +266,14 @@ func testError(t *testing.T, past bool) {
 func testDuplicateAndNewer(t *testing.T, past bool) {
 	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
 	assert.Nil(t, err)
-	regex := regexp.MustCompile(".*/online")
 	latestEvent := interpreter.Event{
-		Destination:     "mac:112233445566/online",
+		Destination:     "event:device-status/mac:112233445566/online",
 		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 		Birthdate:       now.UnixNano(),
 		TransactionUUID: "latest",
 	}
 
-	comparator := Comparators([]Comparator{OlderBootTimeComparator(), DuplicateEventComparator(regex)})
+	comparator := Comparators([]Comparator{OlderBootTimeComparator(), DuplicateEventComparator()})
 	var finder FinderFunc
 	if past {
 		finder = LastSessionFinder(new(mockValidator), comparator)
@@ -294,12 +292,12 @@ func testDuplicateAndNewer(t *testing.T, past bool) {
 			description: "Newer boot-time found",
 			events: []interpreter.Event{
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(1 * time.Hour).Unix())},
 					Birthdate:   now.Add(-1 * time.Hour).UnixNano(),
 				},
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 				},
@@ -312,12 +310,12 @@ func testDuplicateAndNewer(t *testing.T, past bool) {
 			description: "Duplicate event found",
 			events: []interpreter.Event{
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 					Birthdate:   now.UnixNano(),
 				},
 				interpreter.Event{
-					Destination: "mac:112233445566/online",
+					Destination: "event:device-status/mac:112233445566/online",
 					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 				},
@@ -344,7 +342,7 @@ func testNotFound(t *testing.T, past bool) {
 	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
 	assert.Nil(t, err)
 	latestEvent := interpreter.Event{
-		Destination:     "mac:112233445566/online",
+		Destination:     "event:device-status/mac:112233445566/online",
 		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 		Birthdate:       now.UnixNano(),
 		TransactionUUID: "latest",
@@ -380,7 +378,7 @@ func testNotFound(t *testing.T, past bool) {
 			events: []testEvent{
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 						Birthdate:   now.Add(-1 * time.Hour).UnixNano(),
 					},
@@ -389,7 +387,7 @@ func testNotFound(t *testing.T, past bool) {
 				},
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
 					},
@@ -413,7 +411,7 @@ func testNotFound(t *testing.T, past bool) {
 				},
 				testEvent{
 					event: interpreter.Event{
-						Destination: "mac:112233445566/online",
+						Destination: "event:device-status/mac:112233445566/online",
 						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-30 * time.Minute).Unix())},
 						Birthdate:   now.Add(-1 * time.Hour).UnixNano(),
 					},
@@ -460,7 +458,7 @@ func testSuccess(t *testing.T, past bool) {
 	comparator.On("Compare", mock.Anything, mock.Anything).Return(false, nil)
 
 	latestEvent := interpreter.Event{
-		Destination:     "mac:112233445566/online",
+		Destination:     "event:device-status/mac:112233445566/online",
 		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 		Birthdate:       now.UnixNano(),
 		TransactionUUID: "latest",
@@ -468,14 +466,14 @@ func testSuccess(t *testing.T, past bool) {
 	var validEvent interpreter.Event
 	if past {
 		validEvent = interpreter.Event{
-			Destination:     "mac:112233445566/online",
+			Destination:     "event:device-status/mac:112233445566/online",
 			Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 			Birthdate:       now.Add(-1 * time.Hour).UnixNano(),
 			TransactionUUID: "test",
 		}
 	} else {
 		validEvent = interpreter.Event{
-			Destination:     "mac:112233445566/online",
+			Destination:     "event:device-status/mac:112233445566/online",
 			Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 			Birthdate:       now.UnixNano(),
 			TransactionUUID: "test",
@@ -485,7 +483,7 @@ func testSuccess(t *testing.T, past bool) {
 	testEvents := []testEvent{
 		testEvent{
 			event: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-2 * time.Hour).Unix())},
 				Birthdate:       now.Add(-2 * time.Hour).UnixNano(),
 				TransactionUUID: "test",
@@ -498,7 +496,7 @@ func testSuccess(t *testing.T, past bool) {
 		},
 		testEvent{
 			event: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
 				Birthdate:       now.Add(-30 * time.Minute).UnixNano(),
 				TransactionUUID: "test",
@@ -507,7 +505,7 @@ func testSuccess(t *testing.T, past bool) {
 		},
 		testEvent{
 			event: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
 				Birthdate:       now.Add(time.Minute).UnixNano(),
 				TransactionUUID: "test",
@@ -526,7 +524,7 @@ func testSuccess(t *testing.T, past bool) {
 		},
 		testEvent{
 			event: interpreter.Event{
-				Destination:     "mac:112233445566/online",
+				Destination:     "event:device-status/mac:112233445566/online",
 				Birthdate:       now.Add(-1 * time.Hour).UnixNano(),
 				TransactionUUID: "test",
 			},

--- a/history/mocks_test.go
+++ b/history/mocks_test.go
@@ -3,6 +3,7 @@ package history
 import (
 	"github.com/stretchr/testify/mock"
 	"github.com/xmidt-org/interpreter"
+	"github.com/xmidt-org/interpreter/validation"
 )
 
 type mockComparator struct {
@@ -21,4 +22,16 @@ type mockValidator struct {
 func (m *mockValidator) Valid(e interpreter.Event) (bool, error) {
 	args := m.Called(e)
 	return args.Bool(0), args.Error(1)
+}
+
+type testTaggedError struct {
+	tag validation.Tag
+}
+
+func (e testTaggedError) Error() string {
+	return "test error"
+}
+
+func (e testTaggedError) Tag() validation.Tag {
+	return e.tag
 }

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -59,7 +59,7 @@ func (e Errors) Errors() []error {
 }
 
 // Tag implements the TaggedError interface, returning MultipleTags if there are multiple errors with tags.
-// If there is only one one tag, Tag will return it. If no tags exist, Tag returns Unknown.
+// If there is only one error with a tag, Tag will return it. If no tags exist, Tag returns Unknown.
 func (e Errors) Tag() Tag {
 	var tag Tag
 	for _, err := range e {

--- a/validation/errors_test.go
+++ b/validation/errors_test.go
@@ -7,6 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestErrors(t *testing.T) {
+	assert := assert.New(t)
+	errList := []error{errors.New("test"), errors.New("test2"), errors.New("test3")}
+	e := Errors(errList)
+	for _, err := range errList {
+		assert.Contains(e.Error(), err.Error())
+		assert.Contains(e.Errors(), err)
+	}
+}
 func TestInvalidEventErr(t *testing.T) {
 	testErr := testError{
 		err: errors.New("test error"),
@@ -206,6 +215,7 @@ func TestBootDurationErr(t *testing.T) {
 				assert.Contains(err.Error(), tc.underlyingErr.Error())
 			}
 			assert.Contains(err.Error(), "boot duration error")
+			assert.Equal(tc.underlyingErr, err.Unwrap())
 			assert.Equal(tc.expectedTag, err.Tag())
 		})
 	}

--- a/validation/mocks_test.go
+++ b/validation/mocks_test.go
@@ -1,16 +1,16 @@
 package validation
 
 type testError struct {
-	err   error
-	label string
+	err error
+	tag Tag
 }
 
 func (t testError) Error() string {
 	return t.err.Error()
 }
 
-func (t testError) ErrorLabel() string {
-	return t.label
+func (t testError) Tag() Tag {
+	return t.tag
 }
 
 func (t testError) Unwrap() error {

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -21,6 +21,10 @@ const (
 	OldBootTime
 	InvalidBootTime
 	FastBoot
+	InvalidBirthdate
+	MisalignedBirthdate
+	InvalidDestination
+	WrongEventType
 )
 
 var (
@@ -31,7 +35,11 @@ var (
 		OldBootTime:          "old_boot_time",
 		InvalidBootTime:      "invalid_boot_time",
 		FastBoot:             "suspiciously_fast_boot",
+		InvalidBirthdate:     "invalid_birthdate",
+		MisalignedBirthdate:  "misaligned_birthdate",
 		Unknown:              "unknown",
+		InvalidDestination:   "invalid_destination",
+		WrongEventType:       "wrong_event_type",
 	}
 
 	stringToTag = map[string]Tag{
@@ -40,8 +48,12 @@ var (
 		"missing_boot_time":      MissingBootTime,
 		"old_boot_time":          OldBootTime,
 		"invalid_boot_time":      InvalidBootTime,
+		"invalid_birthdate":      InvalidBirthdate,
+		"misaligned_birthdate":   MisalignedBirthdate,
 		"suspiciously_fast_boot": FastBoot,
 		"unknown":                Unknown,
+		"invalid_destination":    InvalidDestination,
+		"wrong_event_type":       WrongEventType,
 	}
 )
 

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -16,6 +16,7 @@ func (t Tag) String() string {
 const (
 	Unknown Tag = iota
 	Pass
+	MultipleTags
 	InconsistentDeviceID
 	InvalidBootTime
 	MissingBootTime
@@ -35,6 +36,7 @@ const (
 const (
 	UnknownStr              = "unknown"
 	PassStr                 = "pass"
+	MultipleTagsStr         = "multiple_tags"
 	InconsistentDeviceIDStr = "inconsistent_device_id"
 	InvalidBootTimeStr      = "invalid_boot_time"
 	MissingBootTimeStr      = "missing_boot_time"
@@ -55,6 +57,7 @@ var (
 	tagToString = map[Tag]string{
 		Unknown:              UnknownStr,
 		Pass:                 PassStr,
+		MultipleTags:         MultipleTagsStr,
 		InconsistentDeviceID: InconsistentDeviceIDStr,
 		InvalidBootTime:      InvalidBootTimeStr,
 		MissingBootTime:      MissingBootTimeStr,
@@ -74,6 +77,7 @@ var (
 	stringToTag = map[string]Tag{
 		UnknownStr:              Unknown,
 		PassStr:                 Pass,
+		MultipleTagsStr:         MultipleTags,
 		InconsistentDeviceIDStr: InconsistentDeviceID,
 		InvalidBootTimeStr:      InvalidBootTime,
 		MissingBootTimeStr:      MissingBootTime,

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -10,7 +10,7 @@ func (t Tag) String() string {
 		return val
 	}
 
-	return "unknown"
+	return UnknownStr
 }
 
 const (
@@ -32,43 +32,62 @@ const (
 	DuplicateEvent
 )
 
+const (
+	UnknownStr              = "unknown"
+	PassStr                 = "pass"
+	InconsistentDeviceIDStr = "inconsistent_device_id"
+	InvalidBootTimeStr      = "invalid_boot_time"
+	MissingBootTimeStr      = "missing_boot_time"
+	OldBootTimeStr          = "suspiciously_old_boot_time"
+	OutdatedBootTimeStr     = "outdated_boot_time"
+	InvalidBootDurationStr  = "invalid_boot_duration"
+	FastBootStr             = "suspiciously_fast_boot"
+	InvalidBirthdateStr     = "invalid_birthdate"
+	MisalignedBirthdateStr  = "misaligned_birthdate"
+	InvalidDestinationStr   = "invalid_destination"
+	NonEventStr             = "not_an_event"
+	InvalidEventTypeStr     = "invalid_event_type"
+	EventTypeMismatchStr    = "event_type_mismatch"
+	DuplicateEventStr       = "duplicate_event"
+)
+
 var (
 	tagToString = map[Tag]string{
-		Unknown:              "unknown",
-		Pass:                 "pass",
-		InconsistentDeviceID: "inconsistent_device_id",
-		InvalidBootTime:      "invalid_boot_time",
-		MissingBootTime:      "missing_boot_time",
-		OldBootTime:          "suspiciously_old_boot_time",
-		OutdatedBootTime:     "outdated_boot_time",
-		InvalidBootDuration:  "invalid_boot_duration",
-		FastBoot:             "suspiciously_fast_boot",
-		InvalidBirthdate:     "invalid_birthdate",
-		MisalignedBirthdate:  "misaligned_birthdate",
-		InvalidDestination:   "invalid_destination",
-		NonEvent:             "not_an_event",
-		InvalidEventType:     "invalid_event_type",
-		EventTypeMismatch:    "event_type_mismatch",
-		DuplicateEvent:       "duplicate_event",
+		Unknown:              UnknownStr,
+		Pass:                 PassStr,
+		InconsistentDeviceID: InconsistentDeviceIDStr,
+		InvalidBootTime:      InvalidBootTimeStr,
+		MissingBootTime:      MissingBootTimeStr,
+		OldBootTime:          OldBootTimeStr,
+		OutdatedBootTime:     OutdatedBootTimeStr,
+		InvalidBootDuration:  InvalidBootDurationStr,
+		FastBoot:             FastBootStr,
+		InvalidBirthdate:     InvalidBirthdateStr,
+		MisalignedBirthdate:  MisalignedBirthdateStr,
+		InvalidDestination:   InvalidDestinationStr,
+		NonEvent:             NonEventStr,
+		InvalidEventType:     InvalidEventTypeStr,
+		EventTypeMismatch:    EventTypeMismatchStr,
+		DuplicateEvent:       DuplicateEventStr,
 	}
 
 	stringToTag = map[string]Tag{
-		"unknown":                    Unknown,
-		"pass":                       Pass,
-		"inconsistent_device_id":     InconsistentDeviceID,
-		"invalid_boot_time":          InvalidBootTime,
-		"missing_boot_time":          MissingBootTime,
-		"suspiciously_old_boot_time": OldBootTime,
-		"outdated_boot_time":         OutdatedBootTime,
-		"invalid_boot_duration":      InvalidBootDuration,
-		"suspiciously_fast_boot":     FastBoot,
-		"invalid_birthdate":          InvalidBirthdate,
-		"misaligned_birthdate":       MisalignedBirthdate,
-		"invalid_destination":        InvalidDestination,
-		"not_an_event":               NonEvent,
-		"invalid_event_type":         InvalidEventType,
-		"event_type_mismatch":        EventTypeMismatch,
-		"duplicate_event":            DuplicateEvent,
+		UnknownStr:              Unknown,
+		PassStr:                 Pass,
+		InconsistentDeviceIDStr: InconsistentDeviceID,
+		InvalidBootTimeStr:      InvalidBootTime,
+		MissingBootTimeStr:      MissingBootTime,
+		OldBootTimeStr:          OldBootTime,
+		OutdatedBootTimeStr:     OutdatedBootTime,
+		InvalidBootDurationStr:  InvalidBootDuration,
+		FastBootStr:             FastBoot,
+		InvalidBirthdateStr:     InvalidBirthdate,
+		MisalignedBirthdateStr:  MisalignedBirthdate,
+		InvalidDestinationStr:   InvalidDestination,
+		NonEventStr:             NonEvent,
+		InvalidEventTypeStr:     InvalidEventType,
+		EventTypeMismatchStr:    EventTypeMismatch,
+		DuplicateEventStr:       DuplicateEvent,
 	}
 )
 

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -17,43 +17,58 @@ const (
 	Unknown Tag = iota
 	Pass
 	InconsistentDeviceID
+	InvalidBootTime
 	MissingBootTime
 	OldBootTime
-	InvalidBootTime
+	OutdatedBootTime
+	InvalidBootDuration
 	FastBoot
 	InvalidBirthdate
 	MisalignedBirthdate
 	InvalidDestination
-	WrongEventType
+	NonEvent
+	InvalidEventType
+	EventTypeMismatch
+	DuplicateEvent
 )
 
 var (
 	tagToString = map[Tag]string{
+		Unknown:              "unknown",
 		Pass:                 "pass",
 		InconsistentDeviceID: "inconsistent_device_id",
-		MissingBootTime:      "missing_boot_time",
-		OldBootTime:          "old_boot_time",
 		InvalidBootTime:      "invalid_boot_time",
+		MissingBootTime:      "missing_boot_time",
+		OldBootTime:          "suspiciously_old_boot_time",
+		OutdatedBootTime:     "outdated_boot_time",
+		InvalidBootDuration:  "invalid_boot_duration",
 		FastBoot:             "suspiciously_fast_boot",
 		InvalidBirthdate:     "invalid_birthdate",
 		MisalignedBirthdate:  "misaligned_birthdate",
-		Unknown:              "unknown",
 		InvalidDestination:   "invalid_destination",
-		WrongEventType:       "wrong_event_type",
+		NonEvent:             "not_an_event",
+		InvalidEventType:     "invalid_event_type",
+		EventTypeMismatch:    "event_type_mismatch",
+		DuplicateEvent:       "duplicate_event",
 	}
 
 	stringToTag = map[string]Tag{
-		"pass":                   Pass,
-		"inconsistent_device_id": InconsistentDeviceID,
-		"missing_boot_time":      MissingBootTime,
-		"old_boot_time":          OldBootTime,
-		"invalid_boot_time":      InvalidBootTime,
-		"invalid_birthdate":      InvalidBirthdate,
-		"misaligned_birthdate":   MisalignedBirthdate,
-		"suspiciously_fast_boot": FastBoot,
-		"unknown":                Unknown,
-		"invalid_destination":    InvalidDestination,
-		"wrong_event_type":       WrongEventType,
+		"unknown":                    Unknown,
+		"pass":                       Pass,
+		"inconsistent_device_id":     InconsistentDeviceID,
+		"invalid_boot_time":          InvalidBootTime,
+		"missing_boot_time":          MissingBootTime,
+		"suspiciously_old_boot_time": OldBootTime,
+		"outdated_boot_time":         OutdatedBootTime,
+		"invalid_boot_duration":      InvalidBootDuration,
+		"suspiciously_fast_boot":     FastBoot,
+		"invalid_birthdate":          InvalidBirthdate,
+		"misaligned_birthdate":       MisalignedBirthdate,
+		"invalid_destination":        InvalidDestination,
+		"not_an_event":               NonEvent,
+		"invalid_event_type":         InvalidEventType,
+		"event_type_mismatch":        EventTypeMismatch,
+		"duplicate_event":            DuplicateEvent,
 	}
 )
 

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -21,7 +21,7 @@ const (
 	InvalidBootTime
 	MissingBootTime
 	OldBootTime
-	OutdatedBootTime
+	NewerBootTimeFound
 	InvalidBootDuration
 	FastBoot
 	InvalidBirthdate
@@ -41,7 +41,7 @@ const (
 	InvalidBootTimeStr      = "invalid_boot_time"
 	MissingBootTimeStr      = "missing_boot_time"
 	OldBootTimeStr          = "suspiciously_old_boot_time"
-	OutdatedBootTimeStr     = "outdated_boot_time"
+	NewerBootTimeFoundStr   = "newer_boot_time_found"
 	InvalidBootDurationStr  = "invalid_boot_duration"
 	FastBootStr             = "suspiciously_fast_boot"
 	InvalidBirthdateStr     = "invalid_birthdate"
@@ -62,7 +62,7 @@ var (
 		InvalidBootTime:      InvalidBootTimeStr,
 		MissingBootTime:      MissingBootTimeStr,
 		OldBootTime:          OldBootTimeStr,
-		OutdatedBootTime:     OutdatedBootTimeStr,
+		NewerBootTimeFound:   NewerBootTimeFoundStr,
 		InvalidBootDuration:  InvalidBootDurationStr,
 		FastBoot:             FastBootStr,
 		InvalidBirthdate:     InvalidBirthdateStr,
@@ -82,7 +82,7 @@ var (
 		InvalidBootTimeStr:      InvalidBootTime,
 		MissingBootTimeStr:      MissingBootTime,
 		OldBootTimeStr:          OldBootTime,
-		OutdatedBootTimeStr:     OutdatedBootTime,
+		NewerBootTimeFoundStr:   NewerBootTimeFound,
 		InvalidBootDurationStr:  InvalidBootDuration,
 		FastBootStr:             FastBoot,
 		InvalidBirthdateStr:     InvalidBirthdate,

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/xmidt-org/interpreter"
@@ -167,7 +168,8 @@ func BirthdateAlignmentValidator(maxDuration time.Duration) ValidatorFunc {
 
 // DestinationValidator takes in a regex and returns a ValidatorFunc that checks if an
 // Event's destination is valid against the EventRegex and this regex.
-func DestinationValidator(regex *regexp.Regexp) ValidatorFunc {
+func DestinationValidator(searchedEventType string) ValidatorFunc {
+	searchedEventType = strings.ToLower(strings.TrimSpace(searchedEventType))
 	return func(e interpreter.Event) (bool, error) {
 		if !interpreter.EventRegex.MatchString(e.Destination) {
 			return false, InvalidDestinationErr{
@@ -177,7 +179,9 @@ func DestinationValidator(regex *regexp.Regexp) ValidatorFunc {
 			}
 		}
 
-		if !regex.MatchString(e.Destination) {
+		eventType, _ := e.EventType()
+		eventType = strings.ToLower(strings.TrimSpace(eventType))
+		if eventType != searchedEventType {
 			return false, InvalidDestinationErr{
 				OriginalErr: ErrEventTypeMismatch,
 				Destination: e.Destination,

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -53,8 +53,8 @@ func (vf ValidatorFunc) Valid(e interpreter.Event) (bool, error) {
 type Validators []Validator
 
 // Valid runs through a list of Validators and checks that the Event
-// is valid against each validator. Returns through all of the validators
-// and returns all of the errors collected from each one. If one validator returns
+// is valid against each validator. It runs through all of the validators
+// and returns the errors collected from each one. If at least one validator returns
 // false, then false is returned.
 func (v Validators) Valid(e interpreter.Event) (bool, error) {
 	var allErrors Errors

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -166,8 +166,8 @@ func BirthdateAlignmentValidator(maxDuration time.Duration) ValidatorFunc {
 	}
 }
 
-// DestinationValidator takes in a regex and returns a ValidatorFunc that checks if an
-// Event's destination is valid against the EventRegex and this regex.
+// DestinationValidator takes in a string and returns a ValidatorFunc that checks if
+// an Event's event type is valid and matches the type being searched for.
 func DestinationValidator(searchedEventType string) ValidatorFunc {
 	searchedEventType = strings.ToLower(strings.TrimSpace(searchedEventType))
 	return func(e interpreter.Event) (bool, error) {

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -75,18 +75,11 @@ func (v Validators) Valid(e interpreter.Event) (bool, error) {
 // BootTimeValidator returns a ValidatorFunc that checks if an
 // Event's boot-time is valid (meaning parsable), greater than 0, and within the
 // bounds deemed valid by the TimeValidation parameters.
-func BootTimeValidator(tv TimeValidation, yearValidator TimeValidation) ValidatorFunc {
+func BootTimeValidator(tv TimeValidation) ValidatorFunc {
 	return func(e interpreter.Event) (bool, error) {
 		bootTime, err := getBootTime(e)
 		if err != nil {
 			return false, err
-		}
-
-		if valid, err := yearValidator.Valid(bootTime); !valid {
-			return false, InvalidBootTimeErr{
-				OriginalErr: err,
-				ErrorTag:    InvalidBootTime,
-			}
 		}
 
 		if valid, err := tv.Valid(bootTime); !valid {

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -26,7 +26,8 @@ func TestValidators(t *testing.T) {
 	})
 	valid, err = validators.Valid(testEvent)
 	assert.False(valid)
-	assert.Equal(errors.New("invalid event"), err)
+	assert.Contains(err.Error(), "invalid event")
+	assert.Contains(err.Error(), "another invalid event")
 }
 
 func testValidator(returnBool bool, returnErr error) ValidatorFunc {
@@ -476,6 +477,121 @@ func TestDestinationTimestampValidator(t *testing.T) {
 				assert.Contains(err.Error(), tc.expectedErr.Error())
 				assert.True(errors.As(err, &taggedError))
 				assert.Equal(tc.expectedTag, taggedError.Tag())
+			}
+		})
+	}
+}
+
+func TestBirthdateAlignmentValidator(t *testing.T) {
+	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
+	assert.Nil(t, err)
+	testDuration := 60 * time.Second
+	val := BirthdateAlignmentValidator(testDuration)
+	tests := []struct {
+		description        string
+		event              interpreter.Event
+		expectedValid      bool
+		expectedTimestamps []int64
+	}{
+		{
+			description: "valid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d", now.Add(5*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			expectedValid: true,
+		},
+		{
+			description: "invalid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d", now.Add(5*time.Minute).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			expectedValid:      false,
+			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix()},
+		},
+		{
+			description: "multiple timestamps valid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Second).Unix(), now.Add(2*time.Second).Unix(), now.Add(10*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			expectedValid: true,
+		},
+		{
+			description: "multiple timestamps invalid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Minute).Unix(), now.Add(2*time.Minute).Unix(), now.Add(10*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			expectedValid:      false,
+			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix(), now.Add(2 * time.Minute).Unix()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			valid, err := val(tc.event)
+			assert.Equal(tc.expectedValid, valid)
+			if tc.expectedValid {
+				assert.Nil(err)
+			} else {
+				var birthdateErr InvalidBirthdateErr
+				assert.True(errors.As(err, &birthdateErr))
+				assert.ElementsMatch(tc.expectedTimestamps, birthdateErr.Timestamps)
+				assert.Equal(tc.event.Destination, birthdateErr.Destination)
+				assert.Equal(MisalignedBirthdate, birthdateErr.Tag())
+			}
+		})
+	}
+}
+
+func TestEventTypesValidator(t *testing.T) {
+	val := EventTypeValidator()
+	tests := []struct {
+		description   string
+		event         interpreter.Event
+		expectedValid bool
+		expectedMatch string
+		expectedErr   error
+	}{
+		{
+			description: "valid",
+			event: interpreter.Event{
+				Destination: "event:device-status/mac:112233445566/online",
+			},
+			expectedValid: true,
+		},
+		{
+			description: "invalid",
+			event: interpreter.Event{
+				Destination: "event:device-status/mac:112233445566/random",
+			},
+			expectedValid: false,
+			expectedMatch: "random",
+			expectedErr:   ErrInvalidEventType,
+		},
+		{
+			description: "no type",
+			event: interpreter.Event{
+				Destination: "event:device-status/mac:112233445566",
+			},
+			expectedValid: false,
+			expectedErr:   ErrInvalidEventType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			valid, err := val.Valid(tc.event)
+			assert.Equal(tc.expectedValid, valid)
+			if tc.expectedErr != nil {
+				var invalidTypeErr InvalidEventTypeErr
+				assert.True(errors.Is(err, tc.expectedErr))
+				assert.True(errors.As(err, &invalidTypeErr))
+				assert.Equal(tc.expectedMatch, invalidTypeErr.EventType)
 			}
 		})
 	}

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -233,7 +233,7 @@ func TestDestinationValidator(t *testing.T) {
 				Destination: "event:device-status/mac:112233445566/random-event/random-string",
 			},
 			valid:       false,
-			expectedErr: ErrInvalidEventType,
+			expectedErr: ErrEventTypeMismatch,
 		},
 		{
 			description: "Invalid event",
@@ -578,7 +578,7 @@ func TestEventTypesValidator(t *testing.T) {
 				Destination: "event:device-status/mac:112233445566",
 			},
 			expectedValid: false,
-			expectedErr:   ErrInvalidEventType,
+			expectedErr:   interpreter.ErrTypeNotFound,
 		},
 	}
 
@@ -588,7 +588,7 @@ func TestEventTypesValidator(t *testing.T) {
 			valid, err := val.Valid(tc.event)
 			assert.Equal(tc.expectedValid, valid)
 			if tc.expectedErr != nil {
-				var invalidTypeErr InvalidEventTypeErr
+				var invalidTypeErr InvalidDestinationErr
 				assert.True(errors.Is(err, tc.expectedErr))
 				assert.True(errors.As(err, &invalidTypeErr))
 				assert.Equal(tc.expectedMatch, invalidTypeErr.EventType)

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -40,9 +40,8 @@ func TestBootTimeValidator(t *testing.T) {
 	assert.Nil(t, err)
 	currTime := func() time.Time { return now }
 	year := 2015
-	timeValidation := TimeValidator{ValidFrom: -2 * time.Hour, ValidTo: time.Hour, Current: currTime}
-	yearValidation := YearValidator{Year: year, Current: currTime}
-	validator := BootTimeValidator(timeValidation, yearValidation)
+	timeValidation := TimeValidator{ValidFrom: -2 * time.Hour, ValidTo: time.Hour, Current: currTime, MinValidYear: year}
+	validator := BootTimeValidator(timeValidation)
 	tests := []struct {
 		description string
 		event       interpreter.Event


### PR DESCRIPTION
This PR:

- Adds validator to validate that the difference between the birthdate and destination timestamps are within a certain time frame 
- Adds validator to validate that an event-type matches one of the possible outcomes.
- Reworks errors to reduce redundancy between `MetricsLogError` and `TaggedError` interfaces.

Closes #20 