### PR TITLE
Event finder fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replace `MetricsLogError` with `TaggedError`. Add validator to futher validate birthdates and event-types. [#21](https://github.com/xmidt-org/interpreter/pull/21)
 - Add `EventsParser` that returns a subset of a list of events. [#26](https://github.com/xmidt-org/interpreter/pull/26)
 - Add `CycleValidator` to validate a list of events. [#29](https://github.com/xmidt-org/interpreter/pull/29)
+- Remove Comparator from `EventFinder`. [#31](https://github.com/xmidt-org/interpreter/pull/31)
 
 ## [v0.0.3]
 - Add labels for errors for prometheus error metrics logging. [#15](https://github.com/xmidt-org/interpreter/pull/15)

--- a/event.go
+++ b/event.go
@@ -56,18 +56,6 @@ var (
 	OnlineEventType        = "online"
 	OfflineEventType       = "offline"
 	RebootPendingEventType = "reboot-pending"
-
-	// EventTypes lists all of the possible device status events.
-	EventTypes = map[string]bool{
-		"reboot-pending":              true,
-		"offline":                     true,
-		"online":                      true,
-		"operational":                 true,
-		"fully-manageable":            true,
-		"non-operational":             true,
-		"firmware-download-started":   true,
-		"firmware-download-completed": true,
-	}
 )
 
 // Event is the struct that contains the wrp.Message fields along with the birthdate

--- a/history/cycleValidator_test.go
+++ b/history/cycleValidator_test.go
@@ -190,7 +190,7 @@ func TestSessionOnlineValidator(t *testing.T) {
 	tests := []struct {
 		description   string
 		events        []interpreter.Event
-		skipFunc      ExcludeFunc
+		skipFunc      func(events []interpreter.Event, id string) bool
 		expectedValid bool
 		expectedIDs   []string
 	}{
@@ -351,7 +351,7 @@ func TestSessionOfflineValidator(t *testing.T) {
 	tests := []struct {
 		description   string
 		events        []interpreter.Event
-		skipFunc      ExcludeFunc
+		skipFunc      func(events []interpreter.Event, id string) bool
 		expectedValid bool
 		expectedIDs   []string
 	}{
@@ -678,7 +678,7 @@ func TestFindSessionsWithoutEvent(t *testing.T) {
 	tests := []struct {
 		description           string
 		events                map[string]bool
-		skipFunc              ExcludeFunc
+		skipFunc              func(events []interpreter.Event, id string) bool
 		expectedInvalidFields []string
 	}{
 		{

--- a/history/cycleValidator_test.go
+++ b/history/cycleValidator_test.go
@@ -190,7 +190,7 @@ func TestSessionOnlineValidator(t *testing.T) {
 	tests := []struct {
 		description   string
 		events        []interpreter.Event
-		skipFunc      func(string) bool
+		skipFunc      ExcludeFunc
 		expectedValid bool
 		expectedIDs   []string
 	}{
@@ -201,7 +201,7 @@ func TestSessionOnlineValidator(t *testing.T) {
 		},
 		{
 			description: "all valid, no skip",
-			skipFunc:    func(id string) bool { return false },
+			skipFunc:    func(events []interpreter.Event, id string) bool { return false },
 			events: []interpreter.Event{
 				interpreter.Event{
 					Destination: "event:device-status/mac:112233445566/online",
@@ -232,7 +232,7 @@ func TestSessionOnlineValidator(t *testing.T) {
 		},
 		{
 			description: "all valid, skip",
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return id == "3"
 			},
 			events: []interpreter.Event{
@@ -261,7 +261,7 @@ func TestSessionOnlineValidator(t *testing.T) {
 		},
 		{
 			description: "invalid-no skip",
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return false
 			},
 			events: []interpreter.Event{
@@ -295,7 +295,7 @@ func TestSessionOnlineValidator(t *testing.T) {
 		},
 		{
 			description: "invalid-skip",
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return id == "4"
 			},
 			events: []interpreter.Event{
@@ -351,7 +351,7 @@ func TestSessionOfflineValidator(t *testing.T) {
 	tests := []struct {
 		description   string
 		events        []interpreter.Event
-		skipFunc      func(string) bool
+		skipFunc      ExcludeFunc
 		expectedValid bool
 		expectedIDs   []string
 	}{
@@ -362,7 +362,7 @@ func TestSessionOfflineValidator(t *testing.T) {
 		},
 		{
 			description: "invalid with skip",
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return id == "5"
 			},
 			events: []interpreter.Event{
@@ -403,7 +403,7 @@ func TestSessionOfflineValidator(t *testing.T) {
 		},
 		{
 			description: "invalid without skip",
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return false
 			},
 			events: []interpreter.Event{
@@ -444,7 +444,7 @@ func TestSessionOfflineValidator(t *testing.T) {
 		},
 		{
 			description: "valid with skip",
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return id == "5"
 			},
 			events: []interpreter.Event{
@@ -678,7 +678,7 @@ func TestFindSessionsWithoutEvent(t *testing.T) {
 	tests := []struct {
 		description           string
 		events                map[string]bool
-		skipFunc              func(string) bool
+		skipFunc              ExcludeFunc
 		expectedInvalidFields []string
 	}{
 		{
@@ -688,7 +688,7 @@ func TestFindSessionsWithoutEvent(t *testing.T) {
 		{
 			description: "valid with skip",
 			events:      map[string]bool{"2": true, "3": true, "1": false},
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return id == "1"
 			},
 		},
@@ -700,7 +700,7 @@ func TestFindSessionsWithoutEvent(t *testing.T) {
 		{
 			description: "invalid with skip",
 			events:      map[string]bool{"1": false, "2": true, "3": false, "4": false},
-			skipFunc: func(id string) bool {
+			skipFunc: func(events []interpreter.Event, id string) bool {
 				return id == "1"
 			},
 			expectedInvalidFields: []string{"3", "4"},
@@ -710,7 +710,7 @@ func TestFindSessionsWithoutEvent(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			invalidFields := findSessionsWithoutEvent(tc.events, tc.skipFunc)
+			invalidFields := findSessionsWithoutEvent(tc.events, []interpreter.Event{}, tc.skipFunc)
 			assert.Equal(len(tc.expectedInvalidFields), len(invalidFields))
 			assert.ElementsMatch(tc.expectedInvalidFields, invalidFields)
 		})

--- a/history/eventFinder_test.go
+++ b/history/eventFinder_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/interpreter"
 	"github.com/xmidt-org/interpreter/validation"
 )
@@ -20,322 +21,42 @@ type testEvent struct {
 }
 
 func TestLastSessionFinder(t *testing.T) {
-	t.Run("general errors", func(t *testing.T) { testError(t, true) })
-	t.Run("duplicate and newer boot-time", func(t *testing.T) { testDuplicateAndNewer(t, true) })
+	t.Run("invalid boot-time", func(t *testing.T) { testInvalidBootTime(t, true) })
 	t.Run("event not found", func(t *testing.T) { testNotFound(t, true) })
 	t.Run("success", func(t *testing.T) { testSuccess(t, true) })
 
 }
 
 func TestCurrentSessionFinder(t *testing.T) {
-	t.Run("general errors", func(t *testing.T) { testError(t, false) })
-	t.Run("duplicate and newer boot-time", func(t *testing.T) { testDuplicateAndNewer(t, false) })
+	t.Run("invalid boot-time", func(t *testing.T) { testInvalidBootTime(t, false) })
 	t.Run("event not found", func(t *testing.T) { testNotFound(t, false) })
 	t.Run("success", func(t *testing.T) { testSuccess(t, false) })
 }
 
-func TestEventHistoryIterator(t *testing.T) {
-	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
-	assert.Nil(t, err)
-	fatalError := errors.New("invalid event")
-	latestEvent := interpreter.Event{
-		Destination:     "event:device-status/mac:112233445566/online",
-		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
-		Birthdate:       now.UnixNano(),
-		TransactionUUID: "latest",
-	}
-
-	tests := []struct {
-		description   string
-		events        []testEvent
-		expectedEvent interpreter.Event
-		latestEvent   interpreter.Event
-		expectedErr   error
-	}{
-		{
-			description: "valid",
-			events: []testEvent{
-				testEvent{
-					event: latestEvent,
-					match: false,
-				},
-				testEvent{
-					event: interpreter.Event{
-						Destination: "event:device-status/mac:112233445566/online",
-						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-					},
-					match: false,
-				},
-			},
-			latestEvent:   latestEvent,
-			expectedEvent: latestEvent,
-		},
-		{
-			description:   "no events",
-			events:        []testEvent{},
-			latestEvent:   latestEvent,
-			expectedEvent: latestEvent,
-		},
-		{
-			description: "same event",
-			events: []testEvent{
-				testEvent{
-					event: latestEvent,
-					match: false,
-				},
-			},
-			latestEvent:   latestEvent,
-			expectedEvent: latestEvent,
-		},
-		{
-			description: "missing boot-time",
-			events: []testEvent{
-				testEvent{
-					event: interpreter.Event{
-						Destination: "event:device-status/mac:112233445566/online",
-						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-					},
-					match: false,
-				},
-			},
-			latestEvent: interpreter.Event{
-				Destination: "event:device-status/mac:112233445566/online",
-				Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-			},
-			expectedEvent: interpreter.Event{},
-			expectedErr:   validation.InvalidBootTimeErr{},
-		},
-		{
-			description: "invalid boot-time",
-			events: []testEvent{
-				testEvent{
-					event: interpreter.Event{
-						Destination: "event:device-status/mac:112233445566/online",
-						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-					},
-					match: false,
-				},
-			},
-			latestEvent: interpreter.Event{
-				Destination: "event:device-status/mac:112233445566/online",
-				Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-				Metadata:    map[string]string{interpreter.BootTimeKey: "-1"},
-			},
-			expectedEvent: interpreter.Event{},
-			expectedErr:   validation.InvalidBootTimeErr{},
-		},
-		{
-			description: "invalid event",
-			events: []testEvent{
-				testEvent{
-					event: interpreter.Event{
-						Destination: "event:device-status/mac:112233445566/online",
-						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-						Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-					},
-					match: false,
-				},
-				testEvent{
-					event: interpreter.Event{
-						Destination: "event:device-status/mac:112233445566/online",
-						Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-3 * time.Minute).Unix())},
-						Birthdate:   now.Add(-3 * time.Minute).UnixNano(),
-					},
-					match: true,
-					err:   fatalError,
-				},
-			},
-			latestEvent:   latestEvent,
-			expectedEvent: interpreter.Event{},
-			expectedErr:   fatalError,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			comparator := new(mockComparator)
-			events := make([]interpreter.Event, 0, len(tc.events))
-			for _, te := range tc.events {
-				comparator.On("Compare", te.event, tc.latestEvent).Return(te.match, te.err)
-				events = append(events, te.event)
-			}
-
-			finder := EventHistoryIterator(comparator)
-			event, err := finder.Find(events, tc.latestEvent)
-			assert.Equal(tc.expectedEvent, event)
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
-			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
-			}
-		})
-	}
-}
-
-func testError(t *testing.T, past bool) {
-	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
-	assert.Nil(t, err)
-
-	comparator := new(mockComparator)
-	fatalError := errors.New("invalid event")
-	comparator.On("Compare", mock.Anything, mock.Anything).Return(true, fatalError)
-	var finder FinderFunc
-	if past {
-		finder = LastSessionFinder(new(mockValidator), comparator)
-	} else {
-		finder = CurrentSessionFinder(new(mockValidator), comparator)
-	}
-
-	tests := []struct {
-		description   string
-		events        []interpreter.Event
-		expectedEvent interpreter.Event
-		latestEvent   interpreter.Event
-		expectedErr   error
-	}{
-		{
-			description: "Non-existent boot-time",
-			events: []interpreter.Event{
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-				},
-			},
-			latestEvent: interpreter.Event{
-				Destination:     "event:device-status/mac:112233445566/online",
-				Birthdate:       now.UnixNano(),
-				TransactionUUID: "latest",
-			},
-			expectedEvent: interpreter.Event{},
-			expectedErr:   validation.InvalidBootTimeErr{},
-		},
-		{
-			description: "Invalid boot-time",
-			events: []interpreter.Event{
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-				},
-			},
-			latestEvent: interpreter.Event{
-				Destination:     "event:device-status/mac:112233445566/online",
-				Metadata:        map[string]string{interpreter.BootTimeKey: "-1"},
-				Birthdate:       now.UnixNano(),
-				TransactionUUID: "latest",
-			},
-			expectedEvent: interpreter.Event{},
-			expectedErr:   validation.InvalidBootTimeErr{},
-		},
-		{
-			description: "Fatal error",
-			events: []interpreter.Event{
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(1 * time.Hour).Unix())},
-					Birthdate:   now.Add(1 * time.Hour).UnixNano(),
-				},
-			},
-			latestEvent: interpreter.Event{
-				Destination:     "event:device-status/mac:112233445566/online",
-				Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
-				Birthdate:       now.UnixNano(),
-				TransactionUUID: "latest",
-			},
-			expectedEvent: interpreter.Event{},
-			expectedErr:   fatalError,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			event, err := finder.Find(tc.events, tc.latestEvent)
-			assert.Equal(tc.expectedEvent, event)
-			assert.NotNil(err)
-			assert.Contains(err.Error(), tc.expectedErr.Error())
-		})
-	}
-}
-
-func testDuplicateAndNewer(t *testing.T, past bool) {
+func testInvalidBootTime(t *testing.T, past bool) {
 	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
 	assert.Nil(t, err)
 	latestEvent := interpreter.Event{
 		Destination:     "event:device-status/mac:112233445566/online",
-		Metadata:        map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
+		Metadata:        map[string]string{},
 		Birthdate:       now.UnixNano(),
 		TransactionUUID: "latest",
 	}
 
-	comparator := Comparators([]Comparator{OlderBootTimeComparator(), DuplicateEventComparator()})
+	assert := assert.New(t)
+	mockVal := new(mockValidator)
+	mockVal.On("Valid", mock.Anything).Return(true, nil)
 	var finder FinderFunc
 	if past {
-		finder = LastSessionFinder(new(mockValidator), comparator)
+		finder = LastSessionFinder(mockVal)
 	} else {
-		finder = CurrentSessionFinder(new(mockValidator), comparator)
+		finder = CurrentSessionFinder(mockVal)
 	}
+	event, err := finder([]interpreter.Event{}, latestEvent)
+	assert.Empty(event)
+	var invalidBootTimeErr validation.InvalidBootTimeErr
+	assert.True(errors.As(err, &invalidBootTimeErr))
 
-	tests := []struct {
-		description   string
-		events        []interpreter.Event
-		expectedEvent interpreter.Event
-		latestEvent   interpreter.Event
-		expectedErr   error
-	}{
-		{
-			description: "Newer boot-time found",
-			events: []interpreter.Event{
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(1 * time.Hour).Unix())},
-					Birthdate:   now.Add(-1 * time.Hour).UnixNano(),
-				},
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-				},
-			},
-			latestEvent:   latestEvent,
-			expectedEvent: interpreter.Event{},
-			expectedErr:   errNewerBootTime,
-		},
-		{
-			description: "Duplicate event found",
-			events: []interpreter.Event{
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Unix())},
-					Birthdate:   now.UnixNano(),
-				},
-				interpreter.Event{
-					Destination: "event:device-status/mac:112233445566/online",
-					Metadata:    map[string]string{interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Hour).Unix())},
-					Birthdate:   now.Add(-30 * time.Minute).UnixNano(),
-				},
-			},
-			latestEvent:   latestEvent,
-			expectedEvent: interpreter.Event{},
-			expectedErr:   errDuplicateEvent,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			tc.events = append(tc.events, tc.latestEvent)
-			event, err := finder.Find(tc.events, tc.latestEvent)
-			assert.Equal(tc.expectedEvent, event)
-			assert.NotNil(err)
-			assert.Contains(err.Error(), tc.expectedErr.Error())
-		})
-	}
 }
 
 func testNotFound(t *testing.T, past bool) {
@@ -347,8 +68,6 @@ func testNotFound(t *testing.T, past bool) {
 		Birthdate:       now.UnixNano(),
 		TransactionUUID: "latest",
 	}
-	comparator := new(mockComparator)
-	comparator.On("Compare", mock.Anything, mock.Anything).Return(false, nil)
 
 	tests := []struct {
 		description   string
@@ -435,9 +154,9 @@ func testNotFound(t *testing.T, past bool) {
 			}
 			var finder FinderFunc
 			if past {
-				finder = LastSessionFinder(mockVal, comparator)
+				finder = LastSessionFinder(mockVal)
 			} else {
-				finder = CurrentSessionFinder(mockVal, comparator)
+				finder = CurrentSessionFinder(mockVal)
 			}
 			event, err := finder(testEvents, latestEvent)
 			assert.Equal(tc.expectedEvent, event)
@@ -454,8 +173,6 @@ func testSuccess(t *testing.T, past bool) {
 	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
 	assert.Nil(t, err)
 	mockVal := new(mockValidator)
-	comparator := new(mockComparator)
-	comparator.On("Compare", mock.Anything, mock.Anything).Return(false, nil)
 
 	latestEvent := interpreter.Event{
 		Destination:     "event:device-status/mac:112233445566/online",
@@ -542,9 +259,9 @@ func testSuccess(t *testing.T, past bool) {
 	assert := assert.New(t)
 	var finder FinderFunc
 	if past {
-		finder = LastSessionFinder(mockVal, comparator)
+		finder = LastSessionFinder(mockVal)
 	} else {
-		finder = CurrentSessionFinder(mockVal, comparator)
+		finder = CurrentSessionFinder(mockVal)
 	}
 	event, err := finder.Find(events, latestEvent)
 	assert.Equal(validEvent, event)

--- a/history/eventFinder_test.go
+++ b/history/eventFinder_test.go
@@ -15,7 +15,6 @@ import (
 
 type testEvent struct {
 	event interpreter.Event
-	match bool
 	valid bool
 	err   error
 }

--- a/history/eventsParser.go
+++ b/history/eventsParser.go
@@ -51,7 +51,8 @@ func BootCycleParser(comparator Comparator, eventValidator validation.Validator)
 				lastCycle = append(lastCycle, event)
 			}
 
-			if bootTime == latestBootTime && event.Birthdate < currentEvent.Birthdate {
+			// make sure event is not the current event
+			if bootTime == latestBootTime && event.Birthdate < currentEvent.Birthdate && event.TransactionUUID != currentEvent.TransactionUUID {
 				currentCycle = append(currentCycle, event)
 			}
 		}

--- a/history/eventsParser.go
+++ b/history/eventsParser.go
@@ -44,7 +44,7 @@ func BootCycleParser(comparator Comparator, eventValidator validation.Validator)
 			// If comparator returns true, it means we should stop parsing
 			// because there is something wrong with currentEvent
 			if match, err := comparator.Compare(event, currentEvent); match {
-				return []interpreter.Event{}, EventFinderErr{OriginalErr: err}
+				return []interpreter.Event{}, err
 			}
 
 			if bootTime > lastBoottime && bootTime < latestBootTime {

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -17,6 +17,7 @@ const (
 	Unknown Tag = iota
 	Pass
 	MultipleTags            // used for multiple errors or cases where there are multiple error tags
+	MissingDeviceID         // device id is missing from the destination
 	InconsistentDeviceID    // occurrences of device id in the event is inconsistent
 	InvalidBootTime         // boot-time is either too far in the past or too far in the future
 	MissingBootTime         // boot-time does not exist in the event's metadata
@@ -41,6 +42,7 @@ const (
 	UnknownStr                 = "unknown"
 	PassStr                    = "pass"
 	MultipleTagsStr            = "multiple_tags"
+	MissingDeviceIDStr         = "missing_device_id"
 	InconsistentDeviceIDStr    = "inconsistent_device_id"
 	InvalidBootTimeStr         = "invalid_boot_time"
 	MissingBootTimeStr         = "missing_boot_time"
@@ -66,6 +68,7 @@ var (
 		Unknown:                 UnknownStr,
 		Pass:                    PassStr,
 		MultipleTags:            MultipleTagsStr,
+		MissingDeviceID:         MissingDeviceIDStr,
 		InconsistentDeviceID:    InconsistentDeviceIDStr,
 		InvalidBootTime:         InvalidBootTimeStr,
 		MissingBootTime:         MissingBootTimeStr,
@@ -90,6 +93,7 @@ var (
 		UnknownStr:                 Unknown,
 		PassStr:                    Pass,
 		MultipleTagsStr:            MultipleTags,
+		MissingDeviceIDStr:         MissingDeviceID,
 		InconsistentDeviceIDStr:    InconsistentDeviceID,
 		InvalidBootTimeStr:         InvalidBootTime,
 		MissingBootTimeStr:         MissingBootTime,

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -16,25 +16,25 @@ func (t Tag) String() string {
 const (
 	Unknown Tag = iota
 	Pass
-	MultipleTags
-	InconsistentDeviceID
-	InvalidBootTime
-	MissingBootTime
-	OldBootTime
-	NewerBootTimeFound
-	InvalidBootDuration
-	FastBoot
-	InvalidBirthdate
-	MisalignedBirthdate
-	InvalidDestination
-	NonEvent
-	InvalidEventType
-	EventTypeMismatch
-	DuplicateEvent
-	InconsistentMetadata
-	RepeatedTransactionUUID
-	MissingOnlineEvent
-	MissingOfflineEvent
+	MultipleTags            // used for multiple errors or cases where there are multiple error tags
+	InconsistentDeviceID    // occurrences of device id in the event is inconsistent
+	InvalidBootTime         // boot-time is either too far in the past or too far in the future
+	MissingBootTime         // boot-time does not exist in the event's metadata
+	OldBootTime             // boot-time is suspiciously old but not old enough to be deemed invalid
+	NewerBootTimeFound      // event does not have the newest boot-time and therefore is an old event
+	InvalidBootDuration     // default tag when event destination's unix timestamps are not in proper time range of event boot-time
+	FastBoot                // event destination's unix timestamps are too close to the boot-time of the event
+	InvalidBirthdate        // birthdate does not fall within a certain time range
+	MisalignedBirthdate     // birthdate is not within a certain time range of the timestamps in the event destination
+	InvalidDestination      // default tag when there is something wrong with the event destination
+	NonEvent                // not an event
+	InvalidEventType        // event type is not one of the possible event types
+	EventTypeMismatch       // event type does not match what is being searched for
+	DuplicateEvent          // duplicate event detected
+	InconsistentMetadata    // metadata values for certain metadata keys are inconsistent
+	RepeatedTransactionUUID // multiple events in an event list have the same transcation uuid
+	MissingOnlineEvent      // session is missing online event
+	MissingOfflineEvent     // session is missing offline event
 )
 
 const (

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -249,7 +249,11 @@ func BootDurationValidator(minDuration time.Duration) ValidatorFunc {
 
 // EventTypeValidator returns a ValidatorFunc that validates that the event-type provided in the destination
 // matches one of the possible outcomes.
-func EventTypeValidator() ValidatorFunc {
+func EventTypeValidator(eventTypes []string) ValidatorFunc {
+	possibleEventTypes := make(map[string]bool)
+	for _, eventType := range eventTypes {
+		possibleEventTypes[eventType] = true
+	}
 	return func(e interpreter.Event) (bool, error) {
 		eventType, err := e.EventType()
 		if err != nil {
@@ -261,7 +265,7 @@ func EventTypeValidator() ValidatorFunc {
 			}
 		}
 
-		if len(eventType) == 0 || !interpreter.EventTypes[eventType] {
+		if len(eventType) == 0 || !possibleEventTypes[eventType] {
 			return false, InvalidDestinationErr{
 				OriginalErr: ErrInvalidEventType,
 				Destination: e.Destination,

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -558,7 +558,7 @@ func TestBirthdateAlignmentValidator(t *testing.T) {
 }
 
 func TestEventTypesValidator(t *testing.T) {
-	val := EventTypeValidator()
+	val := EventTypeValidator([]string{"online", "online", "offline"})
 	tests := []struct {
 		description   string
 		event         interpreter.Event


### PR DESCRIPTION
This PR:

- changes `EventFinder` so that it no longer accepts a comparator and no longer does the comparator check.
- changes the event type validator to take in a slice of valid events. This allow the client to decide what is deemed valid without needing to make the change in interpreter.
- add comments to tags to explain them.

Closes #7, closes #24, closes #25