### PR TITLE
Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Add last cycle and last cycle to current event parsers. [#32](https://github.com/xmidt-org/interpreter/pull/32)
 - Add cycle validators to validate the order of events and that the latest online event is the result of a true reboot. [#33](https://github.com/xmidt-org/interpreter/pull/33)
-- Change parsers to sort event list by newest to oldest. Add current cycle parser. [#34](https://github.com/xmidt-org/interpreter/pull/34)
+- Change parsers to sort event list by newest to oldest, add current cycle parser, add `CycleValidators` type. [#34](https://github.com/xmidt-org/interpreter/pull/34)
 
 ## [v0.0.4]
 - Add validator to validate consistent device id and enhancements to boot-time validator. Introduce tags and `TaggedError` interface. [#18](https://github.com/xmidt-org/interpreter/pull/18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add last cycle and last cycle to current event parsers. [#32](https://github.com/xmidt-org/interpreter/pull/32)
+- Add cycle validators to validate the order of events and that the latest online event is the result of a true reboot. [#33](https://github.com/xmidt-org/interpreter/pull/33)
+- Change parsers to sort event list by newest to oldest. Add current cycle parser. [#34](https://github.com/xmidt-org/interpreter/pull/34)
 
 ## [v0.0.4]
 - Add validator to validate consistent device id and enhancements to boot-time validator. Introduce tags and `TaggedError` interface. [#18](https://github.com/xmidt-org/interpreter/pull/18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Add last cycle and last cycle to current event parsers. [#32](https://github.com/xmidt-org/interpreter/pull/32)
 - Add cycle validators to validate the order of events and that the latest online event is the result of a true reboot. [#33](https://github.com/xmidt-org/interpreter/pull/33)
-- Change parsers to sort event list by newest to oldest, add current cycle parser, add `CycleValidators` type. [#34](https://github.com/xmidt-org/interpreter/pull/34)
+- Change parsers to sort event list by newest to oldest, add current cycle parser, add `CycleValidators` type, change how `RebootParser` works, and add `RebootToCurrentParser`. [#34](https://github.com/xmidt-org/interpreter/pull/34)
 
 ## [v0.0.4]
 - Add validator to validate consistent device id and enhancements to boot-time validator. Introduce tags and `TaggedError` interface. [#18](https://github.com/xmidt-org/interpreter/pull/18)

--- a/event.go
+++ b/event.go
@@ -53,9 +53,11 @@ var (
 	// DeviceIDRegex is used to parse a device id from anywhere.
 	DeviceIDRegex = regexp.MustCompile(fmt.Sprintf(`(?P<%s>(?i)mac|uuid|dns|serial):(?P<%s>[^/]+)`, SchemeSubexpName, AuthoritySubexpName))
 
-	OnlineEventType        = "online"
-	OfflineEventType       = "offline"
-	RebootPendingEventType = "reboot-pending"
+	OnlineEventType          = "online"
+	OfflineEventType         = "offline"
+	RebootPendingEventType   = "reboot-pending"
+	FullyManageableEventType = "fully-manageable"
+	OperationalEventType     = "operational"
 )
 
 // Event is the struct that contains the wrp.Message fields along with the birthdate

--- a/history/cycleValidator.go
+++ b/history/cycleValidator.go
@@ -19,6 +19,11 @@ var (
 	ErrNoReboot             = errors.New("no reboot found")
 )
 
+// CycleValidator validates a list of events.
+type CycleValidator interface {
+	Valid(events []interpreter.Event) (bool, error)
+}
+
 // CycleValidatorFunc is a function type that takes in a slice of events
 // and returns whether the slice of events is valid or not.
 type CycleValidatorFunc func(events []interpreter.Event) (valid bool, err error)
@@ -26,6 +31,35 @@ type CycleValidatorFunc func(events []interpreter.Event) (valid bool, err error)
 // Valid runs the CycleValidatorFunc.
 func (cf CycleValidatorFunc) Valid(events []interpreter.Event) (bool, error) {
 	return cf(events)
+}
+
+// DefaultCycleValidator is a CycleValidator that always returns true and nil.
+func DefaultCycleValidator() CycleValidatorFunc {
+	return func(_ []interpreter.Event) (bool, error) {
+		return true, nil
+	}
+}
+
+// CycleValidators are a list of objects that implement the CycleValidator interface
+type CycleValidators []CycleValidator
+
+// Valid runs through a list of CycleValidators and checks that the list of events
+// is valid against each validator. It runs through all of the validators
+// and returns the errors collected from each one. If at least one validator returns
+// false, then false is returned.
+func (c CycleValidators) Valid(events []interpreter.Event) (bool, error) {
+	var allErrors validation.Errors
+	for _, validator := range c {
+		if valid, err := validator.Valid(events); !valid {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	if len(allErrors) == 0 {
+		return true, nil
+	}
+
+	return false, allErrors
 }
 
 // MetadataValidator takes in a slice of metadata keys and returns a CycleValidatorFunc that

--- a/history/cycleValidator.go
+++ b/history/cycleValidator.go
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package history
 
 import (

--- a/history/eventComparator.go
+++ b/history/eventComparator.go
@@ -44,6 +44,13 @@ func (c ComparatorFunc) Compare(baseEvent interpreter.Event, newEvent interprete
 	return c(baseEvent, newEvent)
 }
 
+// DefaultComparator is a Comparator that always returns false and nil.
+func DefaultComparator() ComparatorFunc {
+	return func(_ interpreter.Event, _ interpreter.Event) (bool, error) {
+		return false, nil
+	}
+}
+
 // Comparators are a list of objects that implement the Comparator interface
 type Comparators []Comparator
 

--- a/history/eventComparator_test.go
+++ b/history/eventComparator_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/xmidt-org/interpreter/validation"
 )
 
+func TestDefaultComparator(t *testing.T) {
+	assert := assert.New(t)
+	comparator := DefaultComparator()
+	bad, err := comparator.Compare(interpreter.Event{}, interpreter.Event{})
+	assert.False(bad)
+	assert.Nil(err)
+}
+
 func TestComparators(t *testing.T) {
 	assert := assert.New(t)
 	testEvent := interpreter.Event{}

--- a/history/eventsParser.go
+++ b/history/eventsParser.go
@@ -40,9 +40,9 @@ func (p EventsParserFunc) Parse(events []interpreter.Event, currentEvent interpr
 // RebootParser returns an EventsParser that takes in a list of events and returns a sorted subset of that list
 // containing events that are relevant to the latest reboot. The slice starts with the last reboot-pending (if available) or last offline event
 // and includes all events afterwards that have a birthdate less than or equal to the current event.
-// The returned slice is sorted from oldest to newest primarily by boot-time, and then by birthdate.
-// RebootParser also runs the list of events through the eventValidator
-// and returns an error containing all of the invalid events with their corresponding errors.
+// The returned slice is sorted from newest to oldest primarily by boot-time, and then by birthdate.
+// RebootParser also runs the list of events CurrentCycleParser also runs the list of events through the comparator
+// to see if the current event is valid.
 func RebootParser(comparator Comparator) EventsParserFunc {
 	comparator = setComparator(comparator)
 	return func(eventsHistory []interpreter.Event, currentEvent interpreter.Event) ([]interpreter.Event, error) {
@@ -58,9 +58,8 @@ func RebootParser(comparator Comparator) EventsParserFunc {
 }
 
 // LastCycleParser returns an EventsParser that takes in a list of events and returns a sorted subset
-// of that list which includes all of the events with the boot-time of the previous cycle sorted from oldest to newest
-// by birthdate. LastCycleParser also runs the list of events through the eventValidator
-// and returns an error containing all of the invalid events with their corresponding errors.
+// of that list which includes all of the events with the boot-time of the previous cycle sorted from newest to oldest
+// by birthdate. LastCycleParser also runs the list of events through the comparator to see if the current event is valid.
 func LastCycleParser(comparator Comparator) EventsParserFunc {
 	comparator = setComparator(comparator)
 	return func(eventsHistory []interpreter.Event, currentEvent interpreter.Event) ([]interpreter.Event, error) {
@@ -73,10 +72,25 @@ func LastCycleParser(comparator Comparator) EventsParserFunc {
 	}
 }
 
+// CurrentCycleParser returns an EventsParser that takes in a list of events and returns a sorted subset
+// of that list which includes all of the events with the boot-time of the current cycle sorted from newest to oldest
+// by birthdate. CurrentCycleParser also runs the list of events through the comparator to see if the current event is valid.
+func CurrentCycleParser(comparator Comparator) EventsParserFunc {
+	comparator = setComparator(comparator)
+	return func(eventsHistory []interpreter.Event, currentEvent interpreter.Event) ([]interpreter.Event, error) {
+		_, currentCycle, err := parserHelper(eventsHistory, currentEvent, comparator)
+		if err != nil {
+			return []interpreter.Event{}, err
+		}
+
+		return currentCycle, nil
+	}
+}
+
 // LastCycleToCurrentParser returns an EventsParser that takes in a list of events and returns a sorted subset
 // of that list. The slice includes all of the events with the boot-time of the previous cycle
 // as well as all events with the latest boot-time that have a birthdate less than or equal to the current event.
-// The returned slice is sorted from oldest to newest primarily by boot-time, and then by birthdate.
+// The returned slice is sorted from newest to oldest primarily by boot-time, and then by birthdate.
 func LastCycleToCurrentParser(comparator Comparator) EventsParserFunc {
 	comparator = setComparator(comparator)
 	return func(eventsHistory []interpreter.Event, currentEvent interpreter.Event) ([]interpreter.Event, error) {

--- a/history/eventsParser.go
+++ b/history/eventsParser.go
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package history
 
 import (

--- a/history/eventsParser_test.go
+++ b/history/eventsParser_test.go
@@ -97,7 +97,7 @@ func (suite *CycleTestSuite) setEventDestination(eventID string, destination str
 }
 
 func (suite *CycleTestSuite) clearEventDestinations() {
-	for i, _ := range suite.Events {
+	for i := range suite.Events {
 		suite.Events[i].Destination = ""
 	}
 }

--- a/history/eventsParser_test.go
+++ b/history/eventsParser_test.go
@@ -67,13 +67,13 @@ func (suite *CycleTestSuite) parseEvents(from interpreter.Event, to interpreter.
 	return eventsCopy[fromIndex : toIndex+1]
 }
 
-func (suite *CycleTestSuite) parseSameBootTime(currentEvent interpreter.Event, upToBirthdate bool) []interpreter.Event {
+func (suite *CycleTestSuite) parseSameBootTime(currentEvent interpreter.Event, upToCurrentEvent bool) []interpreter.Event {
 	currentBootTime, _ := currentEvent.BootTime()
 	var eventsCopy []interpreter.Event
 	for _, event := range suite.Events {
 		bootTime, _ := event.BootTime()
 		if bootTime == currentBootTime {
-			if !upToBirthdate {
+			if !upToCurrentEvent {
 				eventsCopy = append(eventsCopy, event)
 			} else if event.Birthdate <= currentEvent.Birthdate {
 				eventsCopy = append(eventsCopy, event)
@@ -225,6 +225,13 @@ func (suite *CycleTestSuite) TestValidParsers() {
 	suite.Equal(expectedLastCycle, lastCycle)
 	suite.Nil(err)
 
+	// Test CurrentCycleParser
+	expectedCurrentCycle := suite.parseSameBootTime(laterEvent, true)
+	currentCycleParser := CurrentCycleParser(mockComparator)
+	currentCycle, err := currentCycleParser.Parse(suite.Events, laterEvent)
+	suite.Equal(expectedCurrentCycle, currentCycle)
+	suite.Nil(err)
+
 	// Test LastCycleToCurrentParser
 	lastCycleEvents := suite.parseSameBootTime(earlierEvent, false)
 	currentCycleEvents := suite.parseSameBootTime(laterEvent, true)
@@ -310,6 +317,7 @@ func (suite *CycleTestSuite) TestInvalidComparator() {
 	parsers := []EventsParserFunc{
 		RebootParser(mockComparator),
 		LastCycleParser(mockComparator),
+		CurrentCycleParser(mockComparator),
 		LastCycleToCurrentParser(mockComparator),
 	}
 

--- a/history/eventsParser_test.go
+++ b/history/eventsParser_test.go
@@ -228,6 +228,14 @@ func (suite *CycleTestSuite) TestParsersValid() {
 		parseFunc     func(interpreter.Event) bool
 	}{
 		{
+			description:   "default cycle parser",
+			parser:        DefaultCycleParser(mockComparator),
+			startingEvent: eventToChange{eventID: fmt.Sprintf("%d-%d", olderBootTime.Unix(), 1)},
+			endingEvent:   eventToChange{eventID: fmt.Sprintf("%d-%d", futureBootTime.Unix(), 2)},
+			currentEvent:  eventToChange{eventID: fmt.Sprintf("%d-%d", currentBootTime.Unix(), 2)},
+			parseFunc:     func(e interpreter.Event) bool { return true },
+		},
+		{
 			description:   "last cycle parser",
 			parser:        LastCycleParser(mockComparator),
 			startingEvent: eventToChange{eventID: fmt.Sprintf("%d-%d", prevBootTime.Unix(), 1)},
@@ -383,6 +391,7 @@ func (suite *CycleTestSuite) TestInvalidComparator() {
 	mockComparator.On("Compare", mock.Anything, mock.Anything).Return(true, testErr)
 	toEvent := suite.setEventDestination(fmt.Sprintf("%d-%d", currentBootTime.Unix(), 2), "event-device-status/mac:112233445566/some-event")
 	parsers := []EventsParserFunc{
+		DefaultCycleParser(mockComparator),
 		RebootParser(mockComparator),
 		RebootToCurrentParser(mockComparator),
 		LastCycleParser(mockComparator),
@@ -432,6 +441,7 @@ func (suite *CycleTestSuite) TestCurrentEventInvalidBootTime() {
 
 	mockComparator := new(mockComparator)
 	parsers := []EventsParserFunc{
+		DefaultCycleParser(mockComparator),
 		CurrentCycleParser(mockComparator),
 		RebootParser(mockComparator),
 		RebootToCurrentParser(mockComparator),

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package validation
 
 import "strings"

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -50,6 +50,13 @@ func (vf ValidatorFunc) Valid(e interpreter.Event) (bool, error) {
 	return vf(e)
 }
 
+// DefaultValidator is a Validator that always returns true and nil.
+func DefaultValidator() ValidatorFunc {
+	return func(_ interpreter.Event) (bool, error) {
+		return true, nil
+	}
+}
+
 // Validators are a list of objects that implement the Validator interface
 type Validators []Validator
 

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -133,6 +133,9 @@ func BirthdateValidator(tv TimeValidation) ValidatorFunc {
 func BirthdateAlignmentValidator(maxDuration time.Duration) ValidatorFunc {
 	timestampRegex := regexp.MustCompile(`/(?P<content>[^/]+)`)
 	index := timestampRegex.SubexpIndex("content")
+	if maxDuration < 0 {
+		maxDuration = maxDuration * -1
+	}
 	return func(e interpreter.Event) (bool, error) {
 		matches := timestampRegex.FindAllStringSubmatch(e.Destination, -1)
 		birthdate := time.Unix(0, e.Birthdate)
@@ -228,6 +231,9 @@ func ConsistentDeviceIDValidator() ValidatorFunc {
 func BootDurationValidator(minDuration time.Duration) ValidatorFunc {
 	timestampRegex := regexp.MustCompile(`/(?P<content>[^/]+)`)
 	index := timestampRegex.SubexpIndex("content")
+	if minDuration < 0 {
+		minDuration = minDuration * -1
+	}
 	return func(e interpreter.Event) (bool, error) {
 		bootTime, err := getBootTime(e)
 		if err != nil {

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -133,9 +133,7 @@ func BirthdateValidator(tv TimeValidation) ValidatorFunc {
 func BirthdateAlignmentValidator(maxDuration time.Duration) ValidatorFunc {
 	timestampRegex := regexp.MustCompile(`/(?P<content>[^/]+)`)
 	index := timestampRegex.SubexpIndex("content")
-	if maxDuration < 0 {
-		maxDuration = maxDuration * -1
-	}
+	maxDuration = checkDuration(maxDuration)
 	return func(e interpreter.Event) (bool, error) {
 		matches := timestampRegex.FindAllStringSubmatch(e.Destination, -1)
 		birthdate := time.Unix(0, e.Birthdate)
@@ -231,9 +229,7 @@ func ConsistentDeviceIDValidator() ValidatorFunc {
 func BootDurationValidator(minDuration time.Duration) ValidatorFunc {
 	timestampRegex := regexp.MustCompile(`/(?P<content>[^/]+)`)
 	index := timestampRegex.SubexpIndex("content")
-	if minDuration < 0 {
-		minDuration = minDuration * -1
-	}
+	minDuration = checkDuration(minDuration)
 	return func(e interpreter.Event) (bool, error) {
 		bootTime, err := getBootTime(e)
 		if err != nil {
@@ -335,4 +331,12 @@ func getBootTime(e interpreter.Event) (time.Time, error) {
 	}
 
 	return time.Unix(bootTimeInt, 0), nil
+}
+
+func checkDuration(duration time.Duration) time.Duration {
+	if duration < 0 {
+		return -1 * duration
+	}
+
+	return duration
 }

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -124,7 +124,7 @@ func TestBootTimeValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			valid, err := validator(tc.event)
+			valid, err := validator.Valid(tc.event)
 			assert.Equal(tc.valid, valid)
 			if tc.expectedErr == nil || err == nil {
 				assert.Equal(tc.expectedErr, err)
@@ -199,12 +199,101 @@ func TestBirthdateValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			valid, err := validator(tc.event)
+			valid, err := validator.Valid(tc.event)
 			assert.Equal(tc.valid, valid)
 			if tc.expectedErr == nil || err == nil {
 				assert.Equal(tc.expectedErr, err)
 			} else {
 				assert.Contains(err.Error(), tc.expectedErr.Error())
+			}
+		})
+	}
+}
+
+func TestBirthdateAlignmentValidator(t *testing.T) {
+	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
+	assert.Nil(t, err)
+	testDuration := 60 * time.Second
+	tests := []struct {
+		description        string
+		event              interpreter.Event
+		expectedValid      bool
+		duration           time.Duration
+		expectedTimestamps []int64
+	}{
+		{
+			description: "valid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d", now.Add(5*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			duration:      testDuration,
+			expectedValid: true,
+		},
+		{
+			description: "invalid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d", now.Add(5*time.Minute).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			expectedValid:      false,
+			duration:           testDuration,
+			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix()},
+		},
+		{
+			description: "multiple timestamps valid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Second).Unix(), now.Add(2*time.Second).Unix(), now.Add(10*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			duration:      testDuration,
+			expectedValid: true,
+		},
+		{
+			description: "valid with negative duration",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Second).Unix(), now.Add(2*time.Second).Unix(), now.Add(10*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			duration:      testDuration * -1,
+			expectedValid: true,
+		},
+		{
+			description: "multiple timestamps invalid",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Minute).Unix(), now.Add(2*time.Minute).Unix(), now.Add(10*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			duration:           testDuration,
+			expectedValid:      false,
+			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix(), now.Add(2 * time.Minute).Unix()},
+		},
+		{
+			description: "invalid with negative duration",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Minute).Unix(), now.Add(2*time.Minute).Unix(), now.Add(10*time.Second).Unix()),
+				Birthdate:   now.UnixNano(),
+			},
+			duration:           testDuration,
+			expectedValid:      false,
+			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix(), now.Add(2 * time.Minute).Unix()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			val := BirthdateAlignmentValidator(tc.duration)
+			valid, err := val.Valid(tc.event)
+			assert.Equal(tc.expectedValid, valid)
+			if tc.expectedValid {
+				assert.Nil(err)
+			} else {
+				var birthdateErr InvalidBirthdateErr
+				assert.True(errors.As(err, &birthdateErr))
+				assert.ElementsMatch(tc.expectedTimestamps, birthdateErr.Timestamps)
+				assert.Equal(tc.event.Destination, birthdateErr.Destination)
+				assert.Equal(MisalignedBirthdate, birthdateErr.Tag())
 			}
 		})
 	}
@@ -265,7 +354,7 @@ func TestDestinationValidator(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			validator := DestinationValidator(tc.searchedEventType)
-			valid, err := validator(tc.event)
+			valid, err := validator.Valid(tc.event)
 			assert.Equal(tc.valid, valid)
 			if tc.expectedErr == nil || err == nil {
 				assert.Equal(tc.expectedErr, err)
@@ -277,7 +366,7 @@ func TestDestinationValidator(t *testing.T) {
 
 }
 
-func TestDeviceIDValidator(t *testing.T) {
+func TestConsistentDeviceIDValidator(t *testing.T) {
 	val := ConsistentDeviceIDValidator()
 	tests := []struct {
 		description        string
@@ -368,7 +457,7 @@ func TestDeviceIDValidator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			pass, err := val(tc.event)
+			pass, err := val.Valid(tc.event)
 			assert.Equal(tc.expectedConsistent, pass)
 			if !tc.expectedConsistent {
 				var e InconsistentIDErr
@@ -382,7 +471,7 @@ func TestDeviceIDValidator(t *testing.T) {
 	}
 }
 
-func TestDestinationTimestampValidator(t *testing.T) {
+func TestBootDurationValidator(t *testing.T) {
 	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
 	assert.Nil(t, err)
 	tests := []struct {
@@ -416,6 +505,17 @@ func TestDestinationTimestampValidator(t *testing.T) {
 			valid:    true,
 		},
 		{
+			description: "valid with negative duration",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/%d/something-something/%d/%d", now.Add(2*time.Minute).Unix(), now.Add(3*time.Minute).Unix(), now.Add(time.Minute).Unix()),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration: -10 * time.Second,
+			valid:    true,
+		},
+		{
 			description: "valid with no timestamps",
 			event: interpreter.Event{
 				Destination: "event:device-status/serial:112233445566/",
@@ -445,6 +545,19 @@ func TestDestinationTimestampValidator(t *testing.T) {
 				},
 			},
 			duration:    10 * time.Second,
+			valid:       false,
+			expectedErr: BootDurationErr{OriginalErr: ErrFastBoot, ErrorTag: FastBoot},
+			expectedTag: FastBoot,
+		},
+		{
+			description: "invalid with negative duration",
+			event: interpreter.Event{
+				Destination: fmt.Sprintf("event:device-status/serial:112233445566/%d", now.Add(5*time.Second).Unix()),
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			duration:    -10 * time.Second,
 			valid:       false,
 			expectedErr: BootDurationErr{OriginalErr: ErrFastBoot, ErrorTag: FastBoot},
 			expectedTag: FastBoot,
@@ -488,7 +601,7 @@ func TestDestinationTimestampValidator(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 			val := BootDurationValidator(tc.duration)
-			valid, err := val(tc.event)
+			valid, err := val.Valid(tc.event)
 			assert.Equal(tc.valid, valid)
 			if tc.expectedErr != nil {
 				var taggedError TaggedError
@@ -500,72 +613,7 @@ func TestDestinationTimestampValidator(t *testing.T) {
 	}
 }
 
-func TestBirthdateAlignmentValidator(t *testing.T) {
-	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
-	assert.Nil(t, err)
-	testDuration := 60 * time.Second
-	val := BirthdateAlignmentValidator(testDuration)
-	tests := []struct {
-		description        string
-		event              interpreter.Event
-		expectedValid      bool
-		expectedTimestamps []int64
-	}{
-		{
-			description: "valid",
-			event: interpreter.Event{
-				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d", now.Add(5*time.Second).Unix()),
-				Birthdate:   now.UnixNano(),
-			},
-			expectedValid: true,
-		},
-		{
-			description: "invalid",
-			event: interpreter.Event{
-				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d", now.Add(5*time.Minute).Unix()),
-				Birthdate:   now.UnixNano(),
-			},
-			expectedValid:      false,
-			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix()},
-		},
-		{
-			description: "multiple timestamps valid",
-			event: interpreter.Event{
-				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Second).Unix(), now.Add(2*time.Second).Unix(), now.Add(10*time.Second).Unix()),
-				Birthdate:   now.UnixNano(),
-			},
-			expectedValid: true,
-		},
-		{
-			description: "multiple timestamps invalid",
-			event: interpreter.Event{
-				Destination: fmt.Sprintf("event:device-status/mac:112233445566/%d/%d/something/%d", now.Add(5*time.Minute).Unix(), now.Add(2*time.Minute).Unix(), now.Add(10*time.Second).Unix()),
-				Birthdate:   now.UnixNano(),
-			},
-			expectedValid:      false,
-			expectedTimestamps: []int64{now.Add(5 * time.Minute).Unix(), now.Add(2 * time.Minute).Unix()},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			valid, err := val(tc.event)
-			assert.Equal(tc.expectedValid, valid)
-			if tc.expectedValid {
-				assert.Nil(err)
-			} else {
-				var birthdateErr InvalidBirthdateErr
-				assert.True(errors.As(err, &birthdateErr))
-				assert.ElementsMatch(tc.expectedTimestamps, birthdateErr.Timestamps)
-				assert.Equal(tc.event.Destination, birthdateErr.Destination)
-				assert.Equal(MisalignedBirthdate, birthdateErr.Tag())
-			}
-		})
-	}
-}
-
-func TestEventTypesValidator(t *testing.T) {
+func TestEventTypeValidator(t *testing.T) {
 	val := EventTypeValidator([]string{"online", "online", "offline"})
 	tests := []struct {
 		description   string

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/xmidt-org/interpreter"
 )
 
+func TestDefaultValidator(t *testing.T) {
+	assert := assert.New(t)
+	validator := DefaultValidator()
+	valid, err := validator.Valid(interpreter.Event{})
+	assert.True(valid)
+	assert.Nil(err)
+}
+
 func TestValidators(t *testing.T) {
 	assert := assert.New(t)
 	testEvent := interpreter.Event{}


### PR DESCRIPTION
This PR adds:
- Default comparator and validator.
- `CurrentCycleParser` that parses the history of events to return a slice of events with the same boot-time and older birthdate compared to the event passed in.
- Change `RebootParser` so that it only returns events relevant to a device reboot. Added `RebootToCurrentParser` which returns the events starting from the last `reboot-pending` or `offline` event of the previous cycle.
- Changes sorting in parsers to sort by newest to oldest.