### PR TITLE
Current cycle fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ report.json
 
 # Vim
 *.swp
+
+# Mac
+.DS_Store

--- a/cmd/interpreter.yaml
+++ b/cmd/interpreter.yaml
@@ -23,7 +23,7 @@ validators:
     - "online"
     - "operational"
     - "fully-manageable"
-  metadataValidators:
+  metadata:
     - key: "hw-mac"
     - key: "hw-manufacturer"
     - key: "hw-model"
@@ -35,3 +35,7 @@ validators:
       checkWithinCycle: true
     - key: "webpa-protocol"
       checkWithinCycle: true
+  eventOrder:
+    - "fully-manageable"
+    - "operational"
+    - "online"

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -59,6 +59,7 @@ type ValidatorConfig struct {
 	ValidEventTypes            []string
 	BootTimeValidator          TimeValidationConfig
 	BirthdateValidator         TimeValidationConfig
+	EventOrder                 []string
 }
 
 type MetadataKeyConfig struct {
@@ -141,6 +142,7 @@ func createCycleValidators(config ValidatorConfig) history.CycleValidator {
 		history.TransactionUUIDValidator(),
 		history.SessionOnlineValidator(func(_ []interpreter.Event, _ string) bool { return false }),
 		history.SessionOfflineValidator(func(_ []interpreter.Event, _ string) bool { return false }),
+		history.EventOrderValidator(config.EventOrder),
 	}
 	var withinCycleChecks []string
 	var wholeCycleChecks []string

--- a/history/eventsParser.go
+++ b/history/eventsParser.go
@@ -224,7 +224,7 @@ func parserHelper(events []interpreter.Event, currentEvent interpreter.Event, co
 // getSameBootTimeEvents returns a list of events with the same boot-time as the currentEvent, along with the currentEvent.
 // It also runs all of the events in the events list through the comparator, and if the comparator returns true,
 // getSameBootTimeEvents will stop and return an empty slice and the error returned by the comparator.
-// The slice is sorted from newest to oldest.
+// The slice is sorted from newest to oldest by birthdate.
 func getSameBootTimeEvents(events []interpreter.Event, currentEvent interpreter.Event, comparator Comparator) ([]interpreter.Event, error) {
 	latestBootTime, err := currentEvent.BootTime()
 	if err != nil || latestBootTime <= 0 {

--- a/history/eventsParser_test.go
+++ b/history/eventsParser_test.go
@@ -689,6 +689,202 @@ func TestRebootEndParser(t *testing.T) {
 	}
 }
 
+func TestGetSameBootTimeEvents(t *testing.T) {
+	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
+	assert.Nil(t, err)
+	testErr := errors.New("test")
+	events := []interpreter.Event{
+		interpreter.Event{
+			Metadata: map[string]string{
+				interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+			},
+			TransactionUUID: "1",
+		},
+		interpreter.Event{
+			Metadata: map[string]string{
+				interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+			},
+			TransactionUUID: "2",
+		},
+		interpreter.Event{
+			Metadata: map[string]string{
+				interpreter.BootTimeKey: fmt.Sprint(now.Add(time.Minute).Unix()),
+			},
+			TransactionUUID: "4",
+		},
+		interpreter.Event{
+			Metadata: map[string]string{
+				interpreter.BootTimeKey: fmt.Sprint(now.Add(3 * time.Minute).Unix()),
+			},
+			TransactionUUID: "5",
+		},
+		interpreter.Event{
+			Metadata: map[string]string{
+				interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+			},
+			TransactionUUID: "3",
+		},
+		interpreter.Event{
+			Metadata: map[string]string{
+				interpreter.BootTimeKey: fmt.Sprint(now.Add(-1 * time.Minute).Unix()),
+			},
+			TransactionUUID: "6",
+		},
+	}
+
+	invalidComparator := new(mockComparator)
+	validComparator := new(mockComparator)
+	invalidComparator.On("Compare", mock.Anything, mock.Anything).Return(true, testErr)
+	validComparator.On("Compare", mock.Anything, mock.Anything).Return(false, nil)
+
+	tests := []struct {
+		description string
+		event       interpreter.Event
+		comparator  Comparator
+		expectedErr error
+	}{
+		{
+			description: "no current boot-time",
+			event:       interpreter.Event{},
+			expectedErr: interpreter.ErrBootTimeNotFound,
+			comparator:  validComparator,
+		},
+		{
+			description: "success",
+			event: interpreter.Event{
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			comparator: validComparator,
+		},
+		{
+			description: "invalid comparator",
+			event: interpreter.Event{
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+			},
+			comparator:  invalidComparator,
+			expectedErr: testErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			currentBootTime, _ := tc.event.BootTime()
+			var expectedEvents []interpreter.Event
+			expectedEvents = append(expectedEvents, tc.event)
+			for _, event := range events {
+				eventBootTime, _ := event.BootTime()
+				if currentBootTime == eventBootTime {
+					expectedEvents = append(expectedEvents, event)
+				}
+			}
+
+			results, err := getSameBootTimeEvents(events, tc.event, tc.comparator)
+
+			if tc.expectedErr == nil {
+				assert.ElementsMatch(expectedEvents, results)
+				assert.Equal(tc.expectedErr, err)
+			} else {
+				assert.True(errors.Is(err, tc.expectedErr))
+			}
+		})
+	}
+}
+func TestSameEvent(t *testing.T) {
+	now, err := time.Parse(time.RFC3339Nano, "2021-03-02T18:00:01Z")
+	assert.Nil(t, err)
+	tests := []struct {
+		description string
+		eventA      interpreter.Event
+		eventB      interpreter.Event
+		sameEvent   bool
+	}{
+		{
+			description: "same event",
+			eventA: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			eventB: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			sameEvent: true,
+		},
+		{
+			description: "different uuid",
+			eventA: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			eventB: interpreter.Event{
+				TransactionUUID: "abc",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			sameEvent: false,
+		},
+		{
+			description: "different boot-times",
+			eventA: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			eventB: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Add(time.Minute).Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			sameEvent: false,
+		},
+		{
+			description: "different birthdates",
+			eventA: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.UnixNano(),
+			},
+			eventB: interpreter.Event{
+				TransactionUUID: "123",
+				Metadata: map[string]string{
+					interpreter.BootTimeKey: fmt.Sprint(now.Unix()),
+				},
+				Birthdate: now.Add(time.Minute).UnixNano(),
+			},
+			sameEvent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.sameEvent, sameEvent(tc.eventA, tc.eventB))
+		})
+	}
+}
+
 func TestSetComparator(t *testing.T) {
 	assert := assert.New(t)
 	comparator := setComparator(nil)

--- a/history/eventsParser_test.go
+++ b/history/eventsParser_test.go
@@ -254,11 +254,13 @@ func (suite *CycleTestSuite) TestParsersValid() {
 			currentEvent:  eventToChange{eventID: fmt.Sprintf("%d-%d", currentBootTime.Unix(), 2)},
 		},
 		{
-			description:   "current cycle parser",
-			parser:        CurrentCycleParser(mockComparator),
-			startingEvent: eventToChange{eventID: fmt.Sprintf("%d-%d", currentBootTime.Unix(), 1)},
-			endingEvent:   eventToChange{eventID: fmt.Sprintf("%d-%d", currentBootTime.Unix(), 2)},
-			currentEvent:  eventToChange{eventID: fmt.Sprintf("%d-%d", currentBootTime.Unix(), 2)},
+			description:  "current cycle parser",
+			parser:       CurrentCycleParser(mockComparator),
+			currentEvent: eventToChange{eventID: fmt.Sprintf("%d-%d", currentBootTime.Unix(), 2)},
+			parseFunc: func(e interpreter.Event) bool {
+				boottime, _ := e.BootTime()
+				return boottime == currentBootTime.Unix()
+			},
 		},
 		{
 			description: "reboot parser-fully-manageable",

--- a/validation/tag.go
+++ b/validation/tag.go
@@ -153,3 +153,12 @@ func ParseTag(str string) Tag {
 
 	return Unknown
 }
+
+func TagsToStrings(tags []Tag) []string {
+	convertedTags := make([]string, len(tags))
+	for i, tag := range tags {
+		convertedTags[i] = tag.String()
+	}
+
+	return convertedTags
+}

--- a/validation/tag_test.go
+++ b/validation/tag_test.go
@@ -15,6 +15,7 @@ func TestString(t *testing.T) {
 	var nonExistentTag Tag = 1000
 	assert.Equal(t, "unknown", nonExistentTag.String())
 }
+
 func TestParseTag(t *testing.T) {
 	tests := []struct {
 		testStr     string
@@ -43,6 +44,42 @@ func TestParseTag(t *testing.T) {
 			assert := assert.New(t)
 			tag := ParseTag(tc.testStr)
 			assert.Equal(tc.expectedTag, tag)
+		})
+	}
+}
+
+func TestTagsToStrings(t *testing.T) {
+	tests := []struct {
+		description     string
+		tags            []Tag
+		expectedStrings []string
+	}{
+		{
+			description:     "multiple tags",
+			tags:            []Tag{RepeatedTransactionUUID, Unknown, DuplicateEvent, Tag(2000)},
+			expectedStrings: []string{RepeatedTransactionUUIDStr, UnknownStr, DuplicateEventStr, UnknownStr},
+		},
+		{
+			description:     "one tag",
+			tags:            []Tag{RepeatedTransactionUUID},
+			expectedStrings: []string{RepeatedTransactionUUIDStr},
+		},
+		{
+			description:     "empty list",
+			tags:            []Tag{},
+			expectedStrings: []string{},
+		},
+		{
+			description:     "nil list",
+			expectedStrings: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			str := TagsToStrings(tc.tags)
+			assert.ElementsMatch(tc.expectedStrings, str)
 		})
 	}
 }


### PR DESCRIPTION
This PR:
* Fixes #35, fixes #36
* Adds event order validator to command line program
* Adds a `TagsToString` method in the validation package