### PR TITLE
Errors.Error()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- modify error string for `Errors`. [#40](https://github.com/xmidt-org/interpreter/pull/40)
 
 ## [v0.0.6]
 - Add current cycle event parser and better event comparison. [#37](https://github.com/xmidt-org/interpreter/pull/37)

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -49,6 +49,14 @@ type Errors []error
 // Error concatenates the list of error strings to provide a single string
 // that can be used to represent the errors that occurred.
 func (e Errors) Error() string {
+	if len(e) == 0 {
+		return ""
+	}
+
+	if len(e) == 1 {
+		return e[0].Error()
+	}
+
 	var output strings.Builder
 	output.Write([]byte("multiple errors: ["))
 	for i, msg := range e {

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -50,7 +50,7 @@ type Errors []error
 // that can be used to represent the errors that occurred.
 func (e Errors) Error() string {
 	if len(e) == 0 {
-		return ""
+		return "unknown or no errors"
 	}
 
 	if len(e) == 1 {

--- a/validation/errors_test.go
+++ b/validation/errors_test.go
@@ -78,7 +78,7 @@ func TestError(t *testing.T) {
 	err2 := errors.New("test err 2")
 
 	err := make(Errors, 0)
-	assert.Empty(err.Error())
+	assert.Equal("unknown or no errors", err.Error())
 
 	err = Errors([]error{err1, err2})
 	assert.Contains(err.Error(), err1.Error(), err2.Error())

--- a/validation/errors_test.go
+++ b/validation/errors_test.go
@@ -70,8 +70,23 @@ func TestErrors(t *testing.T) {
 			}
 		})
 	}
-
 }
+
+func TestError(t *testing.T) {
+	assert := assert.New(t)
+	err1 := errors.New("test err 1")
+	err2 := errors.New("test err 2")
+
+	err := make(Errors, 0)
+	assert.Empty(err.Error())
+
+	err = Errors([]error{err1, err2})
+	assert.Contains(err.Error(), err1.Error(), err2.Error())
+
+	err = Errors([]error{err1})
+	assert.Equal(err1.Error(), err.Error())
+}
+
 func TestInvalidEventErr(t *testing.T) {
 	testErr := testTaggedErrors{
 		err: errors.New("test error"),


### PR DESCRIPTION
Modify Errors.Error() so that a more accurate error string is returned when there is only one error.